### PR TITLE
feat(integrations): add EasyIQ Lektier widget (0142)

### DIFF
--- a/packages/aula-client/src/index.ts
+++ b/packages/aula-client/src/index.ts
@@ -31,6 +31,8 @@ export {
 export {
   decodeHtmlEntities,
   EasyIqClient,
+  EasyIqLektierClient,
+  type EasyIqLektierOptions,
   type EasyIqOptions,
   EasyIqSkoleportalClient,
   type EasyIqSkoleportalOptions,

--- a/packages/aula-client/src/integrations/easyiq-lektier.ts
+++ b/packages/aula-client/src/integrations/easyiq-lektier.ts
@@ -1,0 +1,295 @@
+/**
+ * EasyIQ Lektier (widget `0142`).
+ *
+ * Same vendor and SaaS host as EasyIQ SkolePortal Ugeplan (`0128`,
+ * `EasyIqSkoleportalClient`), but a distinct controller and a noticeably
+ * different flow: Ugeplan auths per-child and the auth response carries the
+ * loginId you query with. Lektier auths once at the session level, then
+ * `/Aula/GetChildren` returns one `Id` per child — that per-child Id is the
+ * `loginId` query parameter for `/AulaHuskeliste/GetWeekplanEvents`.
+ *
+ * Flow per call:
+ *   1. Get a widget token for `0142` (via WidgetTokenManager).
+ *   2. POST `/Aula/AuthenticateAulaUser` once. The response's `loginId` is
+ *      a session id, NOT a per-child id; we ignore it.
+ *   3. GET `/Aula/GetChildren` → `{ Children: [{ Id, Login, Name }] }`.
+ *      `Login` matches `IntegrationContext.childUserIds[i]`; `Id` is the
+ *      per-child loginId we need.
+ *   4. For each requested child: GET `/AulaHuskeliste/GetWeekplanEvents
+ *      ?loginId=<perChildId>&date=<YYYY-MM-DDT00:00:00.000Z>&activityFilter=null`
+ *      with `x-child` set to that child's Login.
+ *
+ * Reusing the loginId from `AuthenticateAulaUser` (i.e. skipping step 3) does
+ * NOT work — the server returns `200 OK []` for every child, with no error.
+ * This was painful to debug: the empty response masks the wrong-loginId
+ * condition and looks identical to "this kid genuinely has no lektier".
+ *
+ * Response shape mirrors SkolePortal Ugeplan (PascalCase calendar events:
+ * `StartTimeISO`, `CoursesDisplay`, `ActivitiesDisplay`, `Description`,
+ * etc.). Descriptions in Lektier often include HTML (`<p dir="ltr">…</p>`)
+ * pasted from teachers' word processors; we keep markup intact and only
+ * decode entities — the consumer can strip tags as it sees fit.
+ */
+
+import type { AulaHttpClient } from '@aula-mcp/aula-auth';
+import type { WidgetTokenManager } from '../widget-token-manager.ts';
+import { isWidgetTokenExpiredResponse } from '../widget-token-manager.ts';
+import {
+  decodeHtmlEntities,
+  type IntegrationContext,
+  isoDate,
+  isoWeekToMonday,
+  type NormalisedWeekPlan,
+  type NormalisedWeekPlanItem,
+} from './types.ts';
+
+const SP_BASE = 'https://skoleportal.easyiqcloud.dk';
+const SP_AUTH_URL = `${SP_BASE}/Aula/AuthenticateAulaUser`;
+const SP_GET_CHILDREN_URL = `${SP_BASE}/Aula/GetChildren`;
+const SP_LEKTIER_URL = `${SP_BASE}/AulaHuskeliste/GetWeekplanEvents`;
+const SP_WIDGET_ID = '0142';
+// Match the desktop UA Ugeplan uses; SkolePortal's edge tier rate-limits
+// requests that look like bots regardless of the auth header.
+const SP_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36';
+
+interface SpAuthResponse {
+  loginId?: string | number;
+  child?: string;
+  childName?: string;
+  schoolName?: string;
+  schoolId?: string | number;
+}
+
+interface SpChildRow {
+  Id: number;
+  Login: string;
+  Name?: string;
+}
+
+interface SpChildrenResponse {
+  Children?: SpChildRow[];
+}
+
+interface SpEvent {
+  StartTime?: string;
+  StartTimeISO?: string;
+  EndTime?: string;
+  CoursesDisplay?: string;
+  ActivitiesDisplay?: string;
+  ChapterTitle?: string;
+  Title?: string;
+  Description?: string;
+}
+
+export interface EasyIqLektierOptions {
+  http: AulaHttpClient;
+  widgets: WidgetTokenManager;
+  /** Override the widget ID (Aula occasionally renames; making this
+   *  configurable means a config tweak rather than a code patch). */
+  widgetId?: string;
+}
+
+export class EasyIqLektierClient {
+  static readonly id = 'easyiq_lektier' as const;
+  static readonly capabilities = ['lektier'] as const;
+
+  private readonly http: AulaHttpClient;
+  private readonly widgets: WidgetTokenManager;
+  private readonly widgetId: string;
+
+  constructor(opts: EasyIqLektierOptions) {
+    this.http = opts.http;
+    this.widgets = opts.widgets;
+    this.widgetId = opts.widgetId ?? SP_WIDGET_ID;
+  }
+
+  async getLektier(ctx: IntegrationContext): Promise<NormalisedWeekPlan> {
+    const monday = isoWeekToMonday(ctx.isoWeek);
+    const dateParam = `${isoDate(monday)}T00:00:00.000Z`;
+    const items: NormalisedWeekPlanItem[] = [];
+    const warnings: string[] = [];
+    const rawByChild: Record<string, unknown> = {};
+
+    if (ctx.childIds.length === 0) return { items, raw: rawByChild };
+
+    // Auth uses the FIRST child's userId in x-child — matches the browser:
+    // the iframe mounts with the first child selected, then JS calls
+    // GetChildren to enumerate the rest.
+    const firstChildUserId = ctx.childUserIds?.[0];
+    if (!firstChildUserId) {
+      throw new Error(
+        'EasyIQ Lektier needs per-child userId tokens (opaque alphanumeric); none provided',
+      );
+    }
+
+    let auth: SpAuthResponse;
+    try {
+      auth = await this.authenticate(ctx, firstChildUserId);
+    } catch (e) {
+      throw new Error(`Lektier authenticate failed: ${(e as Error).message}`);
+    }
+
+    let childRows: SpChildRow[];
+    try {
+      childRows = await this.getChildren(ctx, firstChildUserId);
+    } catch (e) {
+      throw new Error(`Lektier GetChildren failed: ${(e as Error).message}`);
+    }
+    rawByChild.__getChildren = { auth, children: childRows };
+
+    const childRowByLogin = new Map<string, SpChildRow>();
+    for (const row of childRows) childRowByLogin.set(row.Login, row);
+
+    for (let i = 0; i < ctx.childIds.length; i++) {
+      const childId = ctx.childIds[i];
+      const childUserId = ctx.childUserIds?.[i];
+      if (childId === undefined || !childUserId) continue;
+      const row = childRowByLogin.get(childUserId);
+      if (!row) {
+        warnings.push(
+          `child ${childId} (${childUserId}): not present in /Aula/GetChildren response`,
+        );
+        continue;
+      }
+      try {
+        const events = await this.fetchEvents(ctx, childUserId, String(row.Id), dateParam);
+        rawByChild[String(childId)] = events;
+        const childName = decodeHtmlEntities(row.Name ?? '');
+        for (const ev of events) items.push(this.toItem(ev, childName));
+      } catch (e) {
+        warnings.push(`child ${childId}: ${(e as Error).message}`);
+      }
+    }
+
+    return { items, raw: rawByChild, ...(warnings.length ? { warnings } : {}) };
+  }
+
+  private toItem(ev: SpEvent, childName: string): NormalisedWeekPlanItem {
+    const item: NormalisedWeekPlanItem = { kind: 'lektier' };
+    if (childName) item.childName = childName;
+    const dateStr = ev.StartTimeISO ?? ev.StartTime;
+    if (dateStr) item.date = dateStr;
+    const subject = decodeHtmlEntities(ev.CoursesDisplay ?? '');
+    const cls = decodeHtmlEntities(ev.ActivitiesDisplay ?? '');
+    if (subject || cls) item.subject = [subject, cls].filter(Boolean).join(' / ');
+    // Lektier events typically have a blank `Title` (just whitespace);
+    // `ChapterTitle` is more often populated. Prefer the latter.
+    const titleSrc = ev.ChapterTitle ?? ev.Title ?? '';
+    const title = decodeHtmlEntities(titleSrc).trim();
+    if (title) item.title = title;
+    const desc = decodeHtmlEntities(ev.Description ?? '');
+    if (desc) item.content = desc;
+    return item;
+  }
+
+  /**
+   * Header set per upstream PR scaarup/aula#352 (SkolePortal Ugeplan), with
+   * one Lektier-specific tweak: the `referer` points at `/LektierWidget`,
+   * not `/UgeplanWidget`. Wrong referer → 302 to /Login.
+   */
+  private spHeaders(
+    token: string,
+    childLogin: string,
+    childFilter: string,
+    institutions: string,
+    login: string,
+  ): Record<string, string> {
+    return {
+      accept: '*/*',
+      'accept-language': 'en-US,en;q=0.9,da;q=0.8',
+      authorization: `Bearer ${token}`,
+      origin: SP_BASE,
+      referer: `${SP_BASE}/LektierWidget`,
+      'user-agent': SP_USER_AGENT,
+      'x-child': childLogin,
+      'x-childfilter': childFilter,
+      'x-institutionfilter': institutions,
+      'x-login': login,
+      'x-requested-with': 'Fetch',
+      'x-userprofile': 'guardian',
+    };
+  }
+
+  private async authenticate(
+    ctx: IntegrationContext,
+    firstChildUserId: string,
+  ): Promise<SpAuthResponse> {
+    const childFilter = (ctx.childUserIds ?? []).join(',');
+    return this.widgets.withRetry(this.widgetId, async (token) => {
+      const headers = this.spHeaders(
+        token,
+        firstChildUserId,
+        childFilter,
+        ctx.institutionCodes.join(','),
+        ctx.guardianId,
+      );
+      const res = await this.http.request(SP_AUTH_URL, { method: 'POST', headers });
+      if (isWidgetTokenExpiredResponse(res.body, res.status)) {
+        return { _expired: true as const, status: res.status, bodySnippet: res.body.slice(0, 200) };
+      }
+      if (res.status !== 200) {
+        throw new Error(
+          `AuthenticateAulaUser failed (status ${res.status}): ${res.body.slice(0, 200)}`,
+        );
+      }
+      return JSON.parse(res.body) as SpAuthResponse;
+    });
+  }
+
+  private async getChildren(
+    ctx: IntegrationContext,
+    firstChildUserId: string,
+  ): Promise<SpChildRow[]> {
+    const childFilter = (ctx.childUserIds ?? []).join(',');
+    return this.widgets.withRetry(this.widgetId, async (token) => {
+      const headers = this.spHeaders(
+        token,
+        firstChildUserId,
+        childFilter,
+        ctx.institutionCodes.join(','),
+        ctx.guardianId,
+      );
+      const res = await this.http.request(SP_GET_CHILDREN_URL, { method: 'GET', headers });
+      if (isWidgetTokenExpiredResponse(res.body, res.status)) {
+        return { _expired: true as const, status: res.status, bodySnippet: res.body.slice(0, 200) };
+      }
+      if (res.status !== 200) {
+        throw new Error(`GetChildren failed (status ${res.status}): ${res.body.slice(0, 200)}`);
+      }
+      const parsed = JSON.parse(res.body) as SpChildrenResponse;
+      return parsed.Children ?? [];
+    });
+  }
+
+  private async fetchEvents(
+    ctx: IntegrationContext,
+    childUserId: string,
+    loginId: string,
+    dateParam: string,
+  ): Promise<SpEvent[]> {
+    const childFilter = (ctx.childUserIds ?? []).join(',');
+    return this.widgets.withRetry(this.widgetId, async (token) => {
+      const headers = this.spHeaders(
+        token,
+        childUserId,
+        childFilter,
+        ctx.institutionCodes.join(','),
+        ctx.guardianId,
+      );
+      const url = `${SP_LEKTIER_URL}?loginId=${encodeURIComponent(loginId)}&date=${encodeURIComponent(dateParam)}&activityFilter=null`;
+      const res = await this.http.request(url, { method: 'GET', headers });
+      if (isWidgetTokenExpiredResponse(res.body, res.status)) {
+        return { _expired: true as const, status: res.status, bodySnippet: res.body.slice(0, 200) };
+      }
+      if (res.status !== 200) {
+        throw new Error(
+          `GetWeekplanEvents failed (status ${res.status}): ${res.body.slice(0, 200)}`,
+        );
+      }
+      const parsed = JSON.parse(res.body) as unknown;
+      return Array.isArray(parsed) ? (parsed as SpEvent[]) : [];
+    });
+  }
+}

--- a/packages/aula-client/src/integrations/index.ts
+++ b/packages/aula-client/src/integrations/index.ts
@@ -1,4 +1,5 @@
 export { EasyIqClient, type EasyIqOptions } from './easyiq.ts';
+export { EasyIqLektierClient, type EasyIqLektierOptions } from './easyiq-lektier.ts';
 export {
   EasyIqSkoleportalClient,
   type EasyIqSkoleportalOptions,

--- a/packages/aula-client/src/integrations/integrations.test.ts
+++ b/packages/aula-client/src/integrations/integrations.test.ts
@@ -439,8 +439,8 @@ describe('EasyIqLektierClient.getLektier', () => {
           loginId: 9999,
           loginTypeId: 10,
           child: 'u1234567',
-          childName: 'Lucas Bruun Bech-Larsen',
-          schoolName: 'Vestergårdsskolen',
+          childName: 'Emilie Færgemand',
+          schoolName: 'Demo Skole',
           schoolId: 'D12345',
         }),
       },
@@ -449,8 +449,8 @@ describe('EasyIqLektierClient.getLektier', () => {
         status: 200,
         body: JSON.stringify({
           Children: [
-            { Id: 3113339, Login: 'u1234567', Name: 'Lucas Bruun Bech-Larsen' },
-            { Id: 3053244, Login: 'u9876543', Name: 'Oliver Bruun Bech-Larsen' },
+            { Id: 3113339, Login: 'u1234567', Name: 'Emilie Færgemand' },
+            { Id: 3053244, Login: 'u9876543', Name: 'Rasmus Færgemand' },
           ],
         }),
       },
@@ -479,7 +479,7 @@ describe('EasyIqLektierClient.getLektier', () => {
     );
     expect(plan.items).toHaveLength(1);
     expect(plan.items[0]).toMatchObject({
-      childName: 'Lucas Bruun Bech-Larsen',
+      childName: 'Emilie Færgemand',
       date: '2026-05-13T08:00:00.0000000',
       subject: 'Matematik / 1A',
       // Description's `&aelig;` decoded.
@@ -559,7 +559,7 @@ describe('EasyIqLektierClient.getLektier', () => {
         childIds: [42],
         childUserIds: ['abcd1234'],
         institutionCodes: ['G42', 'G99'],
-        guardianId: 'fili3436',
+        guardianId: 'dema9876',
       }),
     );
     const auth = http.requested[0];
@@ -571,7 +571,7 @@ describe('EasyIqLektierClient.getLektier', () => {
     expect(auth?.headers?.['x-institutionfilter']).toBe('G42,G99');
     // x-login is the Aula guardianId, not the MitID username — confirmed
     // against a captured browser request (the real wire format).
-    expect(auth?.headers?.['x-login']).toBe('fili3436');
+    expect(auth?.headers?.['x-login']).toBe('dema9876');
     expect(auth?.headers?.['authorization']).toBe('Bearer TKN-1');
   });
 });

--- a/packages/aula-client/src/integrations/integrations.test.ts
+++ b/packages/aula-client/src/integrations/integrations.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, test } from 'bun:test';
 import { FakeHttp } from '../test-helpers.ts';
 import type { WidgetTokenManager } from '../widget-token-manager.ts';
 import { EasyIqClient } from './easyiq.ts';
+import { EasyIqLektierClient } from './easyiq-lektier.ts';
 import { EasyIqSkoleportalClient } from './easyiq-skoleportal.ts';
 import { MeebookClient } from './meebook.ts';
 import { MinUddannelseClient } from './min-uddannelse.ts';
@@ -421,6 +422,157 @@ describe('EasyIqSkoleportalClient.getWeekPlan', () => {
     expect(auth?.headers?.['authorization']).toBe('Bearer TKN-1');
     const events = http.requested[1];
     expect(events?.url).toContain('loginId=LOGIN');
+  });
+});
+
+// --------------------------------------------------------------------------
+// EasyIQ Lektier (widget 0142)
+// --------------------------------------------------------------------------
+
+describe('EasyIqLektierClient.getLektier', () => {
+  test('auth + GetChildren + per-child events; maps to NormalisedWeekPlanItem', async () => {
+    const http = new FakeHttp().enqueue(
+      // 1. Auth — session loginId, ignored
+      {
+        status: 200,
+        body: JSON.stringify({
+          loginId: 9999,
+          loginTypeId: 10,
+          child: 'u1234567',
+          childName: 'Lucas Bruun Bech-Larsen',
+          schoolName: 'Vestergårdsskolen',
+          schoolId: 'D12345',
+        }),
+      },
+      // 2. GetChildren — per-child Ids keyed by Login (the userId token)
+      {
+        status: 200,
+        body: JSON.stringify({
+          Children: [
+            { Id: 3113339, Login: 'u1234567', Name: 'Lucas Bruun Bech-Larsen' },
+            { Id: 3053244, Login: 'u9876543', Name: 'Oliver Bruun Bech-Larsen' },
+          ],
+        }),
+      },
+      // 3. Lektier for u1234567
+      {
+        status: 200,
+        body: JSON.stringify([
+          {
+            Id: 15529081,
+            StartTime: '2026/05/13 08:00',
+            StartTimeISO: '2026-05-13T08:00:00.0000000',
+            CoursesDisplay: 'Matematik',
+            ActivitiesDisplay: '1A',
+            Title: ' ',
+            ChapterTitle: null,
+            Description: 'Aflevering af matematikh&aelig;fte med lektier.',
+          },
+        ]),
+      },
+      // 4. Lektier for u9876543 — empty
+      { status: 200, body: '[]' },
+    );
+    const client = new EasyIqLektierClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
+    const plan = await client.getLektier(
+      ctx({ childIds: [1234567, 9876543], childUserIds: ['u1234567', 'u9876543'] }),
+    );
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]).toMatchObject({
+      childName: 'Lucas Bruun Bech-Larsen',
+      date: '2026-05-13T08:00:00.0000000',
+      subject: 'Matematik / 1A',
+      // Description's `&aelig;` decoded.
+      content: expect.stringContaining('matematikhæfte'),
+      kind: 'lektier',
+    });
+    // Title is whitespace-only ⇒ skipped (not set).
+    expect(plan.items[0]?.title).toBeUndefined();
+    expect(plan.warnings).toBeUndefined();
+  });
+
+  test('queries `/Aula/GetChildren` between auth and the per-child fetch', async () => {
+    const http = new FakeHttp().enqueue(
+      { status: 200, body: JSON.stringify({ loginId: 'session-id' }) },
+      { status: 200, body: JSON.stringify({ Children: [{ Id: 1, Login: 'u1' }] }) },
+      { status: 200, body: '[]' },
+    );
+    const client = new EasyIqLektierClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
+    await client.getLektier(ctx({ childIds: [1], childUserIds: ['u1'] }));
+    expect(http.requested[0]?.url).toContain('/Aula/AuthenticateAulaUser');
+    expect(http.requested[1]?.url).toContain('/Aula/GetChildren');
+    expect(http.requested[2]?.url).toContain('/AulaHuskeliste/GetWeekplanEvents');
+    // Per-child loginId from GetChildren feeds the events query as `loginId=1`.
+    expect(http.requested[2]?.url).toContain('loginId=1');
+    // activityFilter is sent as the literal string `null`.
+    expect(http.requested[2]?.url).toContain('activityFilter=null');
+  });
+
+  test('child missing from GetChildren response surfaces as a warning', async () => {
+    const http = new FakeHttp().enqueue(
+      { status: 200, body: JSON.stringify({ loginId: 'session-id' }) },
+      // GetChildren returns only u1; we ask for u1 + u2.
+      { status: 200, body: JSON.stringify({ Children: [{ Id: 1, Login: 'u1', Name: 'A' }] }) },
+      { status: 200, body: JSON.stringify([{ StartTime: '2026/05/04', CoursesDisplay: 'Dansk' }]) },
+    );
+    const client = new EasyIqLektierClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
+    const plan = await client.getLektier(ctx({ childIds: [1, 2], childUserIds: ['u1', 'u2'] }));
+    expect(plan.items).toHaveLength(1);
+    expect(plan.warnings).toBeDefined();
+    expect(plan.warnings?.[0]).toContain('child 2');
+    expect(plan.warnings?.[0]).toContain('GetChildren');
+  });
+
+  test('per-child Lektier fetch error surfaces as warning; other children still succeed', async () => {
+    const http = new FakeHttp().enqueue(
+      { status: 200, body: JSON.stringify({ loginId: 'session-id' }) },
+      {
+        status: 200,
+        body: JSON.stringify({
+          Children: [
+            { Id: 1, Login: 'u1', Name: 'A' },
+            { Id: 2, Login: 'u2', Name: 'B' },
+          ],
+        }),
+      },
+      // u1: 500
+      { status: 500, body: 'oops' },
+      // u2: ok
+      { status: 200, body: JSON.stringify([{ StartTime: '2026/05/04', CoursesDisplay: 'Dansk' }]) },
+    );
+    const client = new EasyIqLektierClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
+    const plan = await client.getLektier(ctx({ childIds: [1, 2], childUserIds: ['u1', 'u2'] }));
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]?.childName).toBe('B');
+    expect(plan.warnings?.[0]).toContain('child 1');
+  });
+
+  test('passes the Lektier-specific headers (referer, x-child, x-childfilter)', async () => {
+    const http = new FakeHttp().enqueue(
+      { status: 200, body: JSON.stringify({ loginId: 'session-id' }) },
+      { status: 200, body: JSON.stringify({ Children: [{ Id: 99, Login: 'abcd1234' }] }) },
+      { status: 200, body: '[]' },
+    );
+    const client = new EasyIqLektierClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
+    await client.getLektier(
+      ctx({
+        childIds: [42],
+        childUserIds: ['abcd1234'],
+        institutionCodes: ['G42', 'G99'],
+        guardianId: 'fili3436',
+      }),
+    );
+    const auth = http.requested[0];
+    // Lektier referer = /LektierWidget (NOT /UgeplanWidget).
+    expect(auth?.headers?.['referer']).toBe('https://skoleportal.easyiqcloud.dk/LektierWidget');
+    // x-child = the child being acted on; x-childfilter = csv of all kids.
+    expect(auth?.headers?.['x-child']).toBe('abcd1234');
+    expect(auth?.headers?.['x-childfilter']).toBe('abcd1234');
+    expect(auth?.headers?.['x-institutionfilter']).toBe('G42,G99');
+    // x-login is the Aula guardianId, not the MitID username — confirmed
+    // against a captured browser request (the real wire format).
+    expect(auth?.headers?.['x-login']).toBe('fili3436');
+    expect(auth?.headers?.['authorization']).toBe('Bearer TKN-1');
   });
 });
 

--- a/packages/mcp-server/src/aula-context.ts
+++ b/packages/mcp-server/src/aula-context.ts
@@ -23,6 +23,7 @@ import {
 import {
   AulaClient,
   EasyIqClient,
+  EasyIqLektierClient,
   EasyIqSkoleportalClient,
   MeebookClient,
   MinUddannelseClient,
@@ -128,6 +129,13 @@ export class AulaContext {
 
   async getEasyIqSkoleportal(): Promise<EasyIqSkoleportalClient> {
     return new EasyIqSkoleportalClient({
+      http: this.http,
+      widgets: await this.getWidgetManager(),
+    });
+  }
+
+  async getEasyIqLektier(): Promise<EasyIqLektierClient> {
+    return new EasyIqLektierClient({
       http: this.http,
       widgets: await this.getWidgetManager(),
     });

--- a/packages/mcp-server/src/discover.test.ts
+++ b/packages/mcp-server/src/discover.test.ts
@@ -80,6 +80,7 @@ describe('buildDiscoverManifest', () => {
     expect(Object.keys(m.capabilities).sort()).toEqual([
       'calendar',
       'huskelisten',
+      'lektier',
       'messages',
       'notifications',
       'opgaver',
@@ -114,18 +115,26 @@ describe('buildDiscoverManifest', () => {
     expect(m.capabilities.ugeplan?.tools[0]).toBe('aula.ugeplan.easyiq_skoleportal');
   });
 
-  test('all five known widgets light up their respective capabilities', async () => {
+  test('all known widgets light up their respective capabilities', async () => {
     const m = await buildDiscoverManifest(
-      fakeContext({ widgets: ['0001', '0029', '0030', '0062', '0128'] }),
+      fakeContext({ widgets: ['0001', '0029', '0030', '0062', '0128', '0142'] }),
     );
-    expect(m.detectedWidgets).toEqual(['0001', '0029', '0030', '0062', '0128']);
+    expect(m.detectedWidgets).toEqual(['0001', '0029', '0030', '0062', '0128', '0142']);
     // ugeplan has both EasyIQ and SkolePortal detected
     expect(m.capabilities.ugeplan?.tools).toContain('aula.ugeplan.easyiq');
     expect(m.capabilities.ugeplan?.tools).toContain('aula.ugeplan.easyiq_skoleportal');
+    // lektier surfaces only when 0142 is detected.
+    expect(m.capabilities.lektier?.tools).toEqual(['aula.lektier.easyiq']);
+    expect(m.capabilities.lektier?.notes).toBeUndefined();
     // No 'not detected' notes for these capabilities
     expect(m.capabilities.opgaver?.notes).toBeUndefined();
     expect(m.capabilities.ugebrev?.notes).toBeUndefined();
     expect(m.capabilities.huskelisten?.notes).toBeUndefined();
+  });
+
+  test('lektier carries a "not detected" note when 0142 absent', async () => {
+    const m = await buildDiscoverManifest(fakeContext({ widgets: [] }));
+    expect(m.capabilities.lektier?.notes).toContain('0142');
   });
 
   test('rawRequestEnabled reflects AULA_MCP_RAW env', async () => {

--- a/packages/mcp-server/src/discover.ts
+++ b/packages/mcp-server/src/discover.ts
@@ -93,6 +93,11 @@ const WIDGET_PROVIDER_MAP: Readonly<
     provider: 'easyiq_skoleportal',
     tool: 'aula.ugeplan.easyiq_skoleportal',
   },
+  '0142': {
+    capability: 'lektier',
+    provider: 'easyiq_lektier',
+    tool: 'aula.lektier.easyiq',
+  },
 });
 
 export async function buildDiscoverManifest(context: AulaContext): Promise<DiscoverManifest> {
@@ -182,6 +187,7 @@ function buildCapabilities(detectedWidgets: string[]): Record<string, Discovered
   const opgaverDetected = detectedByCapability.get('opgaver') ?? [];
   const ugebrevDetected = detectedByCapability.get('ugebrev') ?? [];
   const huskelistenDetected = detectedByCapability.get('huskelisten') ?? [];
+  const lektierDetected = detectedByCapability.get('lektier') ?? [];
 
   // When detection picked a provider for a third-party capability, expose
   // ONLY that tool. Listing alternates as fallbacks invites Claude to fan
@@ -259,6 +265,16 @@ function buildCapabilities(detectedWidgets: string[]): Record<string, Discovered
         ? {
             notes:
               'Systematic widget (0062) not detected — call may return empty. Skip if user did not specifically ask for huskelisten.',
+          }
+        : {}),
+    },
+    lektier: {
+      summary: 'Homework items from EasyIQ Lektier (widget 0142).',
+      tools: ['aula.lektier.easyiq'],
+      ...(lektierDetected.length === 0
+        ? {
+            notes:
+              'EasyIQ Lektier widget (0142) not detected — call may return empty. Skip if user did not specifically ask for lektier.',
           }
         : {}),
     },

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -297,6 +297,22 @@ export function registerTools(server: McpServer, context: AulaContext): void {
   );
 
   server.registerTool(
+    'aula.lektier.easyiq',
+    {
+      title: 'EasyIQ Lektier (homework)',
+      description:
+        'Homework items from EasyIQ Lektier (widget 0142) — same vendor as ' +
+        '`aula.ugeplan.easyiq_skoleportal` but a separate "Lektier" product. ' +
+        'Use when discover.detectedWidgets contains "0142".',
+      inputSchema: integrationContextShape,
+    },
+    async (args) => {
+      const lektier = await context.getEasyIqLektier();
+      return jsonContent(await lektier.getLektier(await buildIntegrationCtx(args)));
+    },
+  );
+
+  server.registerTool(
     'aula.opgaver.minuddannelse',
     {
       title: 'Min Uddannelse opgaveliste',


### PR DESCRIPTION
## Summary

Adds an integration plugin and MCP tool (`aula.lektier.easyiq`) for **EasyIQ Lektier** — the homework-list widget (`0142`) that sits next to EasyIQ SkolePortal Ugeplan (`0128`) at many Danish schools.

Built on top of the existing SkolePortal patterns and verified against a live account with three kids; real homework items returned for each.

## What's new

- `packages/aula-client/src/integrations/easyiq-lektier.ts` — `EasyIqLektierClient` with `getLektier(ctx)` returning `NormalisedWeekPlan` with `kind: 'lektier'`.
- New capability `lektier` and tool `aula.lektier.easyiq` exposed by the MCP server.
- Widget map entry `'0142' → easyiq_lektier` so `discover.ts` lights up the right tool when a school has the widget configured.
- 5 fixture-replay tests covering happy path, header shape, missing-from-GetChildren warning, per-child failure isolation, and the request-sequence ordering.

## Why a separate file from `easyiq-skoleportal.ts`?

Same vendor, same SaaS host, but a **noticeably different flow**:

- SkolePortal **Ugeplan** authenticates per child; the auth response carries the `loginId` used as a query parameter.
- SkolePortal **Lektier** authenticates once at the session level, then a new `/Aula/GetChildren` call returns one `Id` per child — that per-child `Id` is the `loginId` for `/AulaHuskeliste/GetWeekplanEvents`.

This was painful to discover because reusing the auth-response loginId (the obvious thing to try) returns `200 OK []` for every child with no error, indistinguishable from \"this kid genuinely has no lektier\". The integration walks the same path the browser does: auth → GetChildren → per-child query.

A few smaller tweaks that differ from SkolePortal Ugeplan:

- `referer: \`${SP_BASE}/LektierWidget\`` — wrong referer 302s to /Login.
- Both `x-child` (the current kid being queried) and `x-childfilter` (csv of all kids) are sent — Ugeplan only sets one.
- Query string includes `activityFilter=null` (literal string `null`).
- `x-login` is the Aula guardianId (e.g. `fili3436`), confirmed against a captured browser request.

## Verified

- `pnpm typecheck && pnpm lint && bun test` all green (217 tests pass + 1 pre-existing skip).
- Live verification against a real account: three kids, all returning expected lektier (matematik aflevering, læsefidusen reading items, fysik/kemi research questions). Descriptions sometimes contain HTML pasted from teachers' word processors; we decode entities but keep markup intact so the consumer can strip tags as it sees fit.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `bun test`
- [x] Manual end-to-end against live account (auth + GetChildren + 3 children's homework)