### PR TITLE
Add stdio transport for the MCP server

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "aula": "bun apps/cli/src/index.ts",
     "mcp": "bun packages/mcp-server/src/server.ts",
+    "mcp:stdio": "bun packages/mcp-server/src/server-stdio.ts",
     "login": "bun apps/cli/src/index.ts login",
     "doctor": "bun apps/cli/src/index.ts doctor",
     "whoami": "bun apps/cli/src/index.ts whoami",

--- a/packages/aula-auth/src/index.ts
+++ b/packages/aula-auth/src/index.ts
@@ -84,7 +84,7 @@ export {
   KeychainTokenStore,
   type KeychainTokenStoreOptions,
 } from './keychain-token-store.ts';
-export { consoleLogger, type Logger, silentLogger } from './logger.ts';
+export { consoleLogger, type Logger, silentLogger, stderrLogger } from './logger.ts';
 export {
   type AppAuthCallbacks,
   type AppAuthLoopOptions,

--- a/packages/aula-auth/src/logger.ts
+++ b/packages/aula-auth/src/logger.ts
@@ -25,3 +25,21 @@ export function consoleLogger(prefix = 'aula-auth'): Logger {
     error: (m, meta) => console.error(`[${prefix}] ${m}`, meta ?? ''),
   };
 }
+
+/**
+ * Logger that writes every level to stderr. Use this in stdio MCP
+ * servers — stdout is the JSON-RPC channel and `console.info`/`debug`
+ * default to stdout in Node/Bun, which would corrupt the protocol.
+ */
+export function stderrLogger(prefix = 'aula-auth'): Logger {
+  const write = (level: string, m: string, meta?: Record<string, unknown>): void => {
+    const suffix = meta && Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
+    process.stderr.write(`[${prefix}] ${level} ${m}${suffix}\n`);
+  };
+  return {
+    debug: (m, meta) => write('DEBUG', m, meta),
+    info: (m, meta) => write('INFO', m, meta),
+    warn: (m, meta) => write('WARN', m, meta),
+    error: (m, meta) => write('ERROR', m, meta),
+  };
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "dev": "bun --watch src/server.ts",
-    "start": "bun src/server.ts"
+    "start": "bun src/server.ts",
+    "start:stdio": "bun src/server-stdio.ts"
   },
   "dependencies": {
     "@aula-mcp/aula-auth": "workspace:*",

--- a/packages/mcp-server/src/server-stdio.ts
+++ b/packages/mcp-server/src/server-stdio.ts
@@ -1,0 +1,45 @@
+/**
+ * MCP server, stdio transport. Same tool surface as `server.ts`; meant
+ * for spawn-by-agent-runtime use cases (Claude Desktop, Cursor, Cline,
+ * openclaw-gateway) where stdio is the simpler local transport — no
+ * port allocation, no daemon, no loopback-binding decisions.
+ *
+ * IMPORTANT: stdout is the JSON-RPC channel. This file MUST NOT write
+ * anything to stdout itself. Logs go to stderr via `stderrLogger` when
+ * `AULA_MCP_LOG=1`; silent otherwise.
+ *
+ * Env (HTTP-only vars in `server.ts` are ignored here):
+ *   AULA_MCP_DIR     — config dir (default ~/.config/aula-mcp)
+ *   AULA_MCP_KEY     — encryption key for the token store
+ *   AULA_MCP_RAW=1   — enable the aula.raw_request escape hatch
+ *   AULA_MCP_LOG=1   — verbose logs to stderr
+ */
+
+import { silentLogger, stderrLogger } from '@aula-mcp/aula-auth';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createMcpApp } from './setup.ts';
+
+const logger = process.env.AULA_MCP_LOG === '1' ? stderrLogger('aula-mcp') : silentLogger;
+
+const { mcp } = createMcpApp({ logger });
+
+await mcp.connect(new StdioServerTransport());
+
+logger.info('aula-mcp.stdio_ready');
+
+// Graceful shutdown — close the MCP server cleanly so the SDK flushes
+// any in-flight responses before the process exits.
+let shuttingDown = false;
+async function shutdown(signal: NodeJS.Signals): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  logger.info('aula-mcp.shutdown', { signal });
+  try {
+    await mcp.close();
+  } catch (err) {
+    logger.error('aula-mcp.shutdown_error', { error: (err as Error).message });
+  }
+  process.exit(0);
+}
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -7,6 +7,10 @@
  *   DELETE /mcp           — session close
  *   GET  /healthz         — liveness probe
  *
+ * For stdio transport (e.g. spawn-by-agent-runtime use cases like Claude
+ * Desktop, Cursor, Cline), see `server-stdio.ts` — same tool surface,
+ * different transport.
+ *
  * Env:
  *   AULA_MCP_PORT             — port to bind (default 7878)
  *   AULA_MCP_HOST             — interface to bind (default 127.0.0.1)
@@ -20,11 +24,9 @@
  */
 
 import { consoleLogger, silentLogger } from '@aula-mcp/aula-auth';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { Hono } from 'hono';
-import { AulaContext } from './aula-context.ts';
-import { registerTools } from './tools.ts';
+import { createMcpApp } from './setup.ts';
 
 const PORT = Number(process.env.AULA_MCP_PORT ?? 7878);
 const HOST = process.env.AULA_MCP_HOST ?? '127.0.0.1';
@@ -33,44 +35,7 @@ const logger = process.env.AULA_MCP_LOG === '1' ? consoleLogger('aula-mcp') : si
 
 assertSafeBindAddress(HOST);
 
-const context = new AulaContext({ logger });
-
-const mcp = new McpServer(
-  {
-    name: 'aula-mcp',
-    version: '0.0.0',
-  },
-  {
-    capabilities: { tools: {} },
-    instructions: [
-      'This server exposes the Danish school platform Aula to AI agents.',
-      '',
-      'Workflow:',
-      '1. Call `aula.discover` ONCE per session and reuse the manifest. It returns',
-      '   children (with names + ids), institutions, the current API version, and',
-      "   `detectedWidgets` — the widget IDs this user's schools actually have.",
-      '2. Resolve any kid names mentioned in the user prompt against',
-      '   `manifest.children[].name` (case-insensitive, partial — e.g. `luk`',
-      "   matches `Lukas`). Use the matching child's `id` for `childIds` and",
-      '   `userId` for `profileIds` when the tool asks.',
-      '3. Pick ONE subordinate tool, not many. `manifest.capabilities[area].tools[0]`',
-      '   is the right one for this user — only fall back to alternatives if the',
-      "   first errors. Never call ugeplan tools whose widget id isn't in",
-      '   `detectedWidgets`.',
-      "4. Default time windows: when the user says 'denne uge' / 'this week' use",
-      "   `range: 'this_week'`; 'næste uge' → 'next_week'; 'i dag' → 'today'.",
-      "   All times are Europe/Copenhagen — don't shift them.",
-      "5. Reply in the user's language (Danish if they wrote Danish). Dates as",
-      '   `mandag 12. maj`-style, not ISO, unless they ask.',
-      '',
-      "Never re-call `aula.discover` mid-session unless a tool returns 'children",
-      "or widgets unknown' — token refresh is handled server-side, you don't need",
-      'to poll for it.',
-    ].join('\n'),
-  },
-);
-
-registerTools(mcp, context);
+const { mcp } = createMcpApp({ logger });
 
 // Streamable HTTP transport. Stateful mode — the SDK explicitly forbids
 // reusing a *stateless* transport across requests

--- a/packages/mcp-server/src/setup.ts
+++ b/packages/mcp-server/src/setup.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared MCP server construction. Both transports (HTTP in `server.ts`,
+ * stdio in `server-stdio.ts`) wire the same tool surface, instructions,
+ * and AulaContext. Keeping the construction here means only one place
+ * to edit when capabilities or instructions change.
+ */
+
+import type { Logger } from '@aula-mcp/aula-auth';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { AulaContext } from './aula-context.ts';
+import { registerTools } from './tools.ts';
+
+const INSTRUCTIONS = [
+  'This server exposes the Danish school platform Aula to AI agents.',
+  '',
+  'Workflow:',
+  '1. Call `aula.discover` ONCE per session and reuse the manifest. It returns',
+  '   children (with names + ids), institutions, the current API version, and',
+  "   `detectedWidgets` — the widget IDs this user's schools actually have.",
+  '2. Resolve any kid names mentioned in the user prompt against',
+  '   `manifest.children[].name` (case-insensitive, partial — e.g. `luk`',
+  "   matches `Lukas`). Use the matching child's `id` for `childIds` and",
+  '   `userId` for `profileIds` when the tool asks.',
+  '3. Pick ONE subordinate tool, not many. `manifest.capabilities[area].tools[0]`',
+  '   is the right one for this user — only fall back to alternatives if the',
+  "   first errors. Never call ugeplan tools whose widget id isn't in",
+  '   `detectedWidgets`.',
+  "4. Default time windows: when the user says 'denne uge' / 'this week' use",
+  "   `range: 'this_week'`; 'næste uge' → 'next_week'; 'i dag' → 'today'.",
+  "   All times are Europe/Copenhagen — don't shift them.",
+  "5. Reply in the user's language (Danish if they wrote Danish). Dates as",
+  '   `mandag 12. maj`-style, not ISO, unless they ask.',
+  '',
+  "Never re-call `aula.discover` mid-session unless a tool returns 'children",
+  "or widgets unknown' — token refresh is handled server-side, you don't need",
+  'to poll for it.',
+].join('\n');
+
+export interface McpAppOptions {
+  logger: Logger;
+}
+
+export interface McpApp {
+  mcp: McpServer;
+  context: AulaContext;
+}
+
+export function createMcpApp({ logger }: McpAppOptions): McpApp {
+  const context = new AulaContext({ logger });
+  const mcp = new McpServer(
+    {
+      name: 'aula-mcp',
+      version: '0.0.0',
+    },
+    {
+      capabilities: { tools: {} },
+      instructions: INSTRUCTIONS,
+    },
+  );
+  registerTools(mcp, context);
+  return { mcp, context };
+}


### PR DESCRIPTION
## Use case

I want to spawn `aula-mcp` as a stdio child of an MCP-aware agent runtime. The runtime in my case is `openclaw-gateway` running in a NixOS microvm, but this applies equally to Claude Desktop, Cursor, Cline, `mcp-cli`, etc — most agent runtimes default to stdio for local MCP servers and reserve HTTP for remote / shared ones.

Today the server only exposes `WebStandardStreamableHTTPServerTransport` via `Bun.serve`. That means running it locally requires a long-running HTTP daemon, the agent runtime knowing how to speak Streamable-HTTP, port allocation, and loopback-binding-guard handling (`AULA_MCP_ALLOW_REMOTE`). For a single-user, single-agent setup on the same host, stdio is strictly simpler and lower-overhead.

## What this PR does

Three small commits:

1. **`refactor(mcp-server): extract shared setup into setup.ts`** — pulls `McpServer` construction (name, version, capabilities, instructions) and `AulaContext` wiring out of `server.ts` into `createMcpApp()`. No behavior change — `server.ts` produces the same wire shape it did before. This is so two entries can share the tool registration + instructions string without drift.

2. **`feat(aula-auth): add stderrLogger`** — stdio servers can't use `consoleLogger` because `console.info`/`debug` default to stdout in Node/Bun, which corrupts the JSON-RPC channel. `stderrLogger` writes every level to stderr instead. Same prefix + metadata semantics as `consoleLogger`.

3. **`feat(mcp-server): add stdio transport (server-stdio.ts)`** — new entry using `StdioServerTransport`. Reuses `createMcpApp()`. Logging uses `stderrLogger` when `AULA_MCP_LOG=1`, silent otherwise. HTTP-only env vars (`AULA_MCP_PORT`, `AULA_MCP_HOST`, `AULA_MCP_ALLOW_REMOTE`) are silently ignored. Wired as `pnpm mcp:stdio` at the root and `pnpm start:stdio` in `@aula-mcp/mcp-server`.

## Why both transports

HTTP is still the right answer for shared / remote MCP setups (multiple agents over the tailnet, separate auth surface, fronted by an authenticated reverse proxy, etc). Stdio is the right answer for "one agent, same host". Both have a place — this is purely additive, not a replacement.

## Test plan

- [x] `pnpm install --frozen-lockfile` — no changes to lockfile required
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 211 pass, 1 skip, 0 fail (unchanged from `main`)
- [x] `pnpm lint` — no new findings (1 pre-existing info on `packages/aula-client/src/integrations/integrations.test.ts:421`, unrelated)
- [x] Smoke test: piped `initialize` + `notifications/initialized` + `tools/list` over stdin to `bun packages/mcp-server/src/server-stdio.ts`. Protocol round-trips cleanly, all 14 `aula.*` tools listed, stderr stays empty (without `AULA_MCP_LOG=1`).

## Notes on choices made

- **Three commits, not one** — kept the refactor isolated from the new feature so each commit reviews on its own. Happy to squash if you prefer one merge commit.
- **Naming**: `server-stdio.ts` rather than a new `apps/mcp-stdio/` workspace, to keep both transports next to each other and the AulaContext/setup wiring shared. Open to moving it if you'd rather have the stdio entry live elsewhere.
- **No `bun build --compile` target** added for the stdio entry. Easy to add (mirror the CLI's `build:bin` script) if you want a single-binary distribution like `apps/cli`. Held off because I wasn't sure of your preference.
- **No new test for the stdio entry** — the existing `server.test.ts` exercises the tool surface through the HTTP transport, and the stdio entry uses the same `createMcpApp()` factory + the same `registerTools()`. Adding an in-process stdio test would mostly re-test the SDK. If you'd like one anyway, let me know and I'll send a follow-up.

## Bootstrap context

For openclaw I'd run this with:
```
AULA_MCP_DIR=/var/lib/aula-mcp
AULA_MCP_KEY=<sops-rendered hex>
```
and pre-stage `tokens.json` + `.key` from `aula tokens export` on a workstation, per your README's "Move to a server" guidance. Works exactly as documented — the stdio entry doesn't change any of that.

Cheers, and thanks for shipping the auth refactor on this — solving the MitID-once-then-refresh story is the load-bearing piece. 🙏