### PR TITLE
fix(canary): damp Aula edge 403 noise on GHA runners

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -47,18 +47,28 @@ jobs:
           set -e
           status='${{ steps.probe.outputs.status }}'
           location='${{ steps.probe.outputs.location }}'
-          if [ "$status" != "302" ] && [ "$status" != "303" ] && [ "$status" != "307" ]; then
-            echo "::error::Expected 3xx redirect, got HTTP $status"
-            exit 1
-          fi
-          # The redirect should land on the broker or directly on MitID.
-          case "$location" in
-            *broker.unilogin.dk*|*nemlog-in.mitid.dk*|*www.mitid.dk*)
-              echo "::notice::OAuth authorize endpoint healthy → $location"
+          case "$status" in
+            302|303|307)
+              # The redirect should land on the broker or directly on MitID.
+              case "$location" in
+                *broker.unilogin.dk*|*nemlog-in.mitid.dk*|*www.mitid.dk*)
+                  echo "::notice::OAuth authorize endpoint healthy → $location"
+                  ;;
+                *)
+                  echo "::error::Unexpected redirect target: $location"
+                  exit 2
+                  ;;
+              esac
+              ;;
+            403)
+              # Aula's edge intermittently 403s GitHub Actions egress IPs (seen
+              # from 2026-05 onward). Real users don't hit this, so it's not
+              # MitID drift — log and pass instead of paging.
+              echo "::notice::HTTP 403 from Aula edge — likely runner-IP filtering, not OAuth drift."
               ;;
             *)
-              echo "::error::Unexpected redirect target: $location"
-              exit 2
+              echo "::error::Expected 3xx redirect, got HTTP $status"
+              exit 1
               ;;
           esac
 
@@ -78,6 +88,20 @@ jobs:
             // Don't spam — only one open drift issue at a time.
             if (issues.data.some(i => i.title.startsWith('MitID drift canary failed'))) {
               core.info('An open drift issue already exists; not filing another.');
+              return;
+            }
+            // Require the previous scheduled run to have also failed before
+            // opening an issue — single flaps shouldn't page anyone.
+            const recent = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'canary.yml',
+              event: 'schedule',
+              per_page: 5
+            });
+            const previous = recent.data.workflow_runs.find(r => r.id !== context.runId);
+            if (previous && previous.conclusion !== 'failure') {
+              core.info(`Previous scheduled run (${previous.id}) was ${previous.conclusion}; treating this as a flap.`);
               return;
             }
             await github.rest.issues.create({


### PR DESCRIPTION
## Summary

- Carve out HTTP 403 as a logged notice (not an error). Aula's edge started returning 403 to GitHub Actions egress IPs around 2026-05; a probe from a DK egress still returns the expected `302 → broker.unilogin.dk` redirect, so this isn't MitID drift and isn't user-impacting.
- Require the previous scheduled run to have also failed before filing a drift issue. Stops single flaps from paging.

Fixes #7.

## Test plan

- [x] Workflow YAML parses (verified locally with `js-yaml`).
- [ ] Manually trigger via `workflow_dispatch` after merge and confirm: success on a 302, single-flap doesn't open an issue, two consecutive failures do.
- [ ] If tomorrow's scheduled run lands on a 403-blocked runner: workflow exits 0 with a `::notice::` and no issue is filed.