### PR TITLE
feat(ci): automated semver via release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,29 @@
+name: Release Please
+
+# Watches main, accumulates Conventional Commits into a "Release PR" that
+# bumps versions + writes CHANGELOG.md. Merging the Release PR tags the
+# release and creates a GitHub Release with the changelog as the body —
+# which then triggers `release.yml` to compile + attach the binaries.
+#
+# Bump rules (Conventional Commits):
+#   fix:                                    → patch
+#   feat:                                   → minor
+#   feat!: / fix!: / BREAKING CHANGE footer → major
+#   chore:/docs:/refactor:/ci:/test:        → no bump (listed under "Misc")
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,12 +86,16 @@ jobs:
       - name: Inspect artifacts
         run: ls -la artifacts/
 
+      # release-please owns the release body (auto-generated changelog).
+      # We append the install snippet as a footer below it so both the
+      # changelog and install instructions appear in the GitHub Release UI.
       - uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*
-          generate_release_notes: true
           fail_on_unmatched_files: true
+          append_body: true
           body: |
+            ---
             ## Install
 
             Download the binary for your platform, mark executable, and put it on your PATH:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,7 @@
+{
+  ".": "0.0.0",
+  "apps/cli": "0.0.0",
+  "packages/aula-auth": "0.0.0",
+  "packages/aula-client": "0.0.0",
+  "packages/mcp-server": "0.0.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "include-component-in-tag": false,
+  "separate-pull-requests": false,
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "aula-mcp",
+      "components": [
+        "aula-mcp",
+        "@aula-mcp/cli",
+        "@aula-mcp/aula-auth",
+        "@aula-mcp/aula-client",
+        "@aula-mcp/mcp-server"
+      ]
+    }
+  ],
+  "packages": {
+    ".": { "package-name": "aula-mcp" },
+    "apps/cli": { "package-name": "@aula-mcp/cli" },
+    "packages/aula-auth": { "package-name": "@aula-mcp/aula-auth" },
+    "packages/aula-client": { "package-name": "@aula-mcp/aula-client" },
+    "packages/mcp-server": { "package-name": "@aula-mcp/mcp-server" }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-please.yml` that watches `main`, accumulates Conventional Commits since the last release, and opens/updates a "Release PR" with the version bump + generated `CHANGELOG.md`.
- Adds `release-please-config.json` + `.release-please-manifest.json` — single repo-wide version, linked across all 5 workspace packages (`aula-mcp`, `@aula-mcp/cli`, `@aula-mcp/aula-auth`, `@aula-mcp/aula-client`, `@aula-mcp/mcp-server`).
- Updates `release.yml` to `append_body: true` so the install snippet sits *below* the auto-generated changelog instead of overwriting it.

## How it flows after merge

1. Any conventional commit lands on `main` (e.g. `feat(integrations): …`).
2. The release-please workflow runs, opens or updates a PR titled `chore(main): release X.Y.Z`. The PR shows the proposed version + changelog.
3. Merging the Release PR pushes tag `vX.Y.Z` + creates the GitHub Release with the changelog as the body.
4. The existing `release.yml` fires on the tag, builds the binaries, and appends them + the install snippet to the release.

## Bump rules

| Prefix | Bump |
| --- | --- |
| `fix:` | patch |
| `feat:` | minor |
| `feat!:` / `fix!:` / `BREAKING CHANGE:` footer | major |
| `chore:` / `docs:` / `refactor:` / `ci:` / `test:` | none (still listed under Misc in the changelog) |

Dependabot's `chore(deps):` commits won't trigger a release on their own — good, they shouldn't.

## Test plan

- [x] `release-please-config.json` + `.release-please-manifest.json` parse as valid JSON
- [x] All workflow YAMLs parse (`release-please.yml`, `release.yml`, `canary.yml`, `ci.yml`)
- [ ] After merge: confirm the first run of `release-please.yml` opens a Release PR proposing `0.1.0` (or whatever it computes from history)
- [ ] Merge the Release PR → confirm tag `v0.1.0` is pushed and triggers `release.yml`
- [ ] Confirm the resulting GitHub Release shows the changelog *and* the install snippet appended below