### PR TITLE
fix(release-please): cap pre-1.0 feats at minor bump

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "release-type": "node",
   "include-component-in-tag": false,
   "separate-pull-requests": false,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "plugins": [
     {
       "type": "linked-versions",


### PR DESCRIPTION
## Summary

The first release-please dry-run on \`main\` (after #13 + #8 landed) proposed \`0.0.0 → 1.0.0\`. We want pre-1.0 semantics until we explicitly cut 1.0.0, so adds two flags to \`release-please-config.json\`:

- \`bump-minor-pre-major: true\` — \`feat:\` from 0.x → 0.(x+1).0
- \`bump-patch-for-minor-pre-major: false\` — \`fix:\` from 0.x → 0.x.(y+1)

Net effect: the next Release PR will propose **0.1.0** instead of 1.0.0.

## Also fixed (out-of-band)

The first run also failed with \`GitHub Actions is not permitted to create or approve pull requests\`. Flipped the repo setting via API (\`PATCH /repos/.../actions/permissions/workflow\` → \`default_workflow_permissions=write\`, \`can_approve_pull_request_reviews=true\`). Not part of this PR (it's a repo-level setting, not a file), but worth knowing the workflow couldn't run without it.

## Test plan

- [x] Config still parses as valid JSON.
- [ ] After merge: confirm the release-please workflow run succeeds and opens a Release PR proposing \`0.1.0\`.