### PR TITLE
fix(release): PAT for release-please + workflow_dispatch on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,5 +25,11 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # Tags pushed by GITHUB_TOKEN don't trigger downstream workflows
+          # (anti-recursion). Pass a PAT so the tag push fires release.yml
+          # automatically. Falls back to GITHUB_TOKEN if the secret is not
+          # set — release-please still works, but you'll need to dispatch
+          # release.yml manually after each Release PR merges.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  # Tag pushes from the GITHUB_TOKEN (e.g. when release-please creates
+  # a release) do NOT fire workflow runs — GitHub's anti-recursion rule.
+  # workflow_dispatch lets us rebuild binaries onto an existing tag with:
+  #   gh workflow run release.yml --ref v1.2.3
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

After v1.0.0 was cut by release-please earlier today, \`release.yml\` never fired and the GitHub Release ended up empty (no binaries). Root cause: tag pushes from \`GITHUB_TOKEN\` don't trigger downstream workflow runs (GitHub anti-recursion rule). Two fixes:

1. **\`release.yml\` gains \`workflow_dispatch\`** so we can rebuild binaries onto an existing tag without re-tagging:
   \`\`\`
   gh workflow run release.yml --ref v1.2.3
   \`\`\`
   I'll use this immediately to backfill v1.0.0's binaries.

2. **\`release-please.yml\` now passes a token** to the action:
   - Prefers \`secrets.RELEASE_PLEASE_TOKEN\` (a PAT with \`repo\` + \`workflow\` scope). Tag pushes from a PAT *do* fire downstream workflows, so \`release.yml\` runs automatically after each Release PR merges.
   - Falls back to \`secrets.GITHUB_TOKEN\` if the secret isn't set — release-please still works, you just dispatch release.yml manually each time.

## One thing for you to do

Create the PAT secret so the automation is end-to-end:

1. https://github.com/settings/tokens → "Generate new token (classic)" with scopes \`repo\` + \`workflow\`. (Fine-grained PAT also works if you'd rather scope to this repo only — needs Contents: read/write, Pull requests: read/write, Actions: read/write.)
2. Repo Settings → Secrets and variables → Actions → New repository secret → name \`RELEASE_PLEASE_TOKEN\`, value = the PAT.

Until that secret exists, \`||\` in the action falls back to \`GITHUB_TOKEN\` and you'll get release-please's PRs but not auto-binaries.

## Test plan

- [x] Both workflow YAMLs parse.
- [ ] After merge: \`gh workflow run release.yml --ref v1.0.0\` builds + attaches binaries to the existing v1.0.0 release.
- [ ] After PAT is set + next Release PR merges: \`release.yml\` should fire on its own.