### PR TITLE
feat(mcp-server): legacy SSE transport for Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ aula.dithjem.dk {
 
 Den nemmeste vej for HA-brugere bliver en addon der pakker `aula-mcp` ind, så den kører som en del af din HA-installation og er tilgængelig fra HA's Voice/Assist + alle dine HA-automatiseringer. Hvis du har **Nabu Casa**, åbner det også for sikker fjernadgang via deres tunnel.
 
+`aula-mcp` taler både den nye Streamable HTTP-protokol (`/mcp`) og den ældre SSE-dialekt (`/sse`) — HA's officielle [`mcp` (client) integration](https://www.home-assistant.io/integrations/mcp/) bruger SSE, så du peger den bare på `http://<ha-host>:7878/sse`, så har Assist + dit valgte LLM (Anthropic / OpenAI / Ollama) adgang til alle `aula.*` tools.
+
 > 🛣️ Spores som [issue (TBD)] — feedback fra HA-folk meget velkommen. Hvis du har erfaring med HA add-on-byggeri, så bliver det her din hjælp.
 
 ### Mulighed 4: VPS i Tyskland (Hetzner, Coolify)

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -5,6 +5,10 @@
  *   POST /mcp             — MCP JSON-RPC requests (Streamable HTTP transport)
  *   GET  /mcp             — Streamable HTTP SSE channel
  *   DELETE /mcp           — session close
+ *   GET  /sse             — Legacy MCP SSE transport (Home Assistant's MCP
+ *                           client integration speaks this dialect)
+ *   POST /messages        — Client→server channel for the /sse session,
+ *                           selected by ?sessionId=… query param
  *   GET  /healthz         — liveness probe
  *
  * For stdio transport (e.g. spawn-by-agent-runtime use cases like Claude
@@ -25,8 +29,11 @@
 
 import { consoleLogger, silentLogger } from '@aula-mcp/aula-auth';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import { Hono } from 'hono';
-import { createMcpApp } from './setup.ts';
+import { streamSSE } from 'hono/streaming';
+import { createMcpApp, type McpApp } from './setup.ts';
+import { HonoSseTransport } from './sse-transport.ts';
 
 const PORT = Number(process.env.AULA_MCP_PORT ?? 7878);
 const HOST = process.env.AULA_MCP_HOST ?? '127.0.0.1';
@@ -58,6 +65,91 @@ const handleMcp = async (request: Request): Promise<Response> => transport.handl
 app.post('/mcp', (c) => handleMcp(c.req.raw));
 app.get('/mcp', (c) => handleMcp(c.req.raw));
 app.delete('/mcp', (c) => handleMcp(c.req.raw));
+
+// Legacy MCP SSE transport — for clients that haven't moved to Streamable HTTP
+// yet, notably Home Assistant's official `mcp` (client) integration. Each
+// GET /sse opens a fresh session: own McpServer instance, own AulaContext,
+// own sessionId. POSTs to /messages?sessionId=… get routed back to the
+// matching session's transport.
+interface SseSession {
+  transport: HonoSseTransport;
+  app: McpApp;
+}
+const sseSessions = new Map<string, SseSession>();
+
+app.get('/sse', (c) =>
+  streamSSE(c, async (stream) => {
+    const sessionId = crypto.randomUUID();
+    const sseTransport = new HonoSseTransport({
+      sessionId,
+      messageEndpoint: '/messages',
+      stream,
+    });
+    // McpServer.connect() binds a single transport, so we instantiate a
+    // fresh server per SSE connection. AulaContext is cheap to construct
+    // — it just lazily wraps the shared token store on first call.
+    const sessionApp = createMcpApp({ logger });
+    sseSessions.set(sessionId, { transport: sseTransport, app: sessionApp });
+
+    const closed = new Promise<void>((resolve) => {
+      stream.onAbort(async () => {
+        sseSessions.delete(sessionId);
+        try {
+          await sseTransport.close();
+        } catch (err) {
+          logger.error('aula-mcp.sse.transport_close_error', {
+            sessionId,
+            error: (err as Error).message,
+          });
+        }
+        try {
+          await sessionApp.mcp.close();
+        } catch (err) {
+          logger.error('aula-mcp.sse.mcp_close_error', {
+            sessionId,
+            error: (err as Error).message,
+          });
+        }
+        resolve();
+      });
+    });
+
+    try {
+      // mcp.connect() calls transport.start(), which writes the spec-required
+      // first event (`endpoint`) telling the client where to POST.
+      await sessionApp.mcp.connect(sseTransport);
+      logger.info('aula-mcp.sse.session_opened', { sessionId });
+    } catch (err) {
+      logger.error('aula-mcp.sse.connect_failed', {
+        sessionId,
+        error: (err as Error).message,
+      });
+      sseSessions.delete(sessionId);
+      return;
+    }
+
+    // Hold the SSE stream open until the client disconnects.
+    await closed;
+    logger.info('aula-mcp.sse.session_closed', { sessionId });
+  }),
+);
+
+app.post('/messages', async (c) => {
+  const sessionId = c.req.query('sessionId');
+  if (!sessionId) return c.json({ error: 'missing sessionId query parameter' }, 400);
+  const session = sseSessions.get(sessionId);
+  if (!session) return c.json({ error: 'unknown sessionId' }, 404);
+  let body: JSONRPCMessage;
+  try {
+    body = (await c.req.json()) as JSONRPCMessage;
+  } catch {
+    return c.json({ error: 'invalid JSON body' }, 400);
+  }
+  session.transport.receive(body);
+  // The actual JSON-RPC response is delivered over the SSE channel; the POST
+  // is just an inbound carrier, so 202 Accepted is the spec-correct ack.
+  return c.body(null, 202);
+});
 
 logger.info('aula-mcp.listening', { host: HOST, port: PORT });
 process.stdout.write(`aula-mcp listening on http://${HOST}:${PORT}/mcp (healthz at /healthz)\n`);

--- a/packages/mcp-server/src/sse-transport.test.ts
+++ b/packages/mcp-server/src/sse-transport.test.ts
@@ -1,0 +1,377 @@
+/**
+ * In-process MCP SSE protocol test. Mounts the SSE routes against a fresh
+ * Hono app + a one-tool McpServer, then drives the legacy SSE handshake
+ * through `app.fetch()` (no `Bun.serve`, no real network).
+ *
+ * Covers: endpoint announce, initialize round-trip, tools/list, tools/call,
+ * unknown sessionId, multiple concurrent sessions.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import { Hono } from 'hono';
+import { streamSSE } from 'hono/streaming';
+import { z } from 'zod';
+import { HonoSseTransport } from './sse-transport.ts';
+
+interface SseSession {
+  transport: HonoSseTransport;
+  mcp: McpServer;
+}
+
+/**
+ * Builds the smallest possible SSE-enabled MCP app for testing. Mirrors
+ * the wiring in `server.ts` but with a single in-memory tool so we never
+ * touch Aula/AulaContext.
+ */
+function buildTestApp(): Hono {
+  const sessions = new Map<string, SseSession>();
+  const app = new Hono();
+
+  app.get('/sse', (c) =>
+    streamSSE(c, async (stream) => {
+      const sessionId = crypto.randomUUID();
+      const transport = new HonoSseTransport({
+        sessionId,
+        messageEndpoint: '/messages',
+        stream,
+      });
+      const mcp = new McpServer(
+        { name: 'aula-mcp-test', version: '0.0.0' },
+        { capabilities: { tools: {} } },
+      );
+      mcp.registerTool(
+        'echo',
+        {
+          title: 'Echo',
+          description: 'Echoes its input back as a text content block.',
+          inputSchema: { msg: z.string() },
+        },
+        async ({ msg }) => ({ content: [{ type: 'text', text: msg }] }),
+      );
+      sessions.set(sessionId, { transport, mcp });
+
+      const closed = new Promise<void>((resolve) => {
+        stream.onAbort(async () => {
+          sessions.delete(sessionId);
+          try {
+            await transport.close();
+          } catch {}
+          try {
+            await mcp.close();
+          } catch {}
+          resolve();
+        });
+      });
+
+      await mcp.connect(transport);
+      await closed;
+    }),
+  );
+
+  app.post('/messages', async (c) => {
+    const sessionId = c.req.query('sessionId');
+    if (!sessionId) return c.json({ error: 'missing sessionId' }, 400);
+    const session = sessions.get(sessionId);
+    if (!session) return c.json({ error: 'unknown sessionId' }, 404);
+    const body = (await c.req.json()) as JSONRPCMessage;
+    session.transport.receive(body);
+    return c.body(null, 202);
+  });
+
+  return app;
+}
+
+interface SseEvent {
+  event?: string;
+  data: string;
+}
+
+/**
+ * SSE event reader over a ReadableStream<Uint8Array>. Buffers partial chunks
+ * and yields one event at a time via `next()`. Throws on timeout so a hung
+ * test fails loudly instead of hanging the suite.
+ */
+class SseReader {
+  private buffer = '';
+  private readonly decoder = new TextDecoder();
+  // The DOM-lib `ReadableStreamDefaultReader` and Bun/Node's `node:stream/web`
+  // variant differ on the presence of `readMany`; using a structural type
+  // avoids the cross-lib variance without dragging either import in.
+  private readonly reader: {
+    read(): Promise<{ value?: Uint8Array; done: boolean }>;
+    cancel(): Promise<void>;
+    releaseLock(): void;
+  };
+  private readonly queue: SseEvent[] = [];
+  private streamEnded = false;
+
+  constructor(stream: ReadableStream<Uint8Array>) {
+    this.reader = stream.getReader() as unknown as typeof this.reader;
+  }
+
+  async next(timeoutMs = 5000): Promise<SseEvent> {
+    if (this.queue.length > 0) return this.queue.shift() as SseEvent;
+    const deadline = Date.now() + timeoutMs;
+    while (this.queue.length === 0) {
+      if (Date.now() > deadline) {
+        throw new Error(
+          `SseReader.next() timed out after ${timeoutMs}ms (buffer="${this.buffer.slice(0, 80)}")`,
+        );
+      }
+      if (this.streamEnded) throw new Error('SSE stream ended with no event');
+      const { value, done } = await this.reader.read();
+      if (done) {
+        this.streamEnded = true;
+        if (this.queue.length === 0) throw new Error('SSE stream ended with no event');
+        break;
+      }
+      this.buffer += this.decoder.decode(value, { stream: true });
+      this.parseBuffer();
+    }
+    return this.queue.shift() as SseEvent;
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.reader.cancel();
+    } catch {}
+    try {
+      this.reader.releaseLock();
+    } catch {}
+  }
+
+  private parseBuffer(): void {
+    let sepIdx = this.buffer.indexOf('\n\n');
+    while (sepIdx !== -1) {
+      const chunk = this.buffer.slice(0, sepIdx);
+      this.buffer = this.buffer.slice(sepIdx + 2);
+      const ev: SseEvent = { data: '' };
+      for (const line of chunk.split('\n')) {
+        const colon = line.indexOf(':');
+        if (colon <= 0) continue;
+        const field = line.slice(0, colon);
+        const v = line.slice(colon + 1).replace(/^ /, '');
+        if (field === 'event') ev.event = v;
+        else if (field === 'data') ev.data = ev.data ? `${ev.data}\n${v}` : v;
+      }
+      if (ev.event !== undefined || ev.data !== '') this.queue.push(ev);
+      sepIdx = this.buffer.indexOf('\n\n');
+    }
+  }
+}
+
+async function openSse(
+  app: Hono,
+): Promise<{ reader: SseReader; sessionId: string; res: Response }> {
+  const res = await app.fetch(new Request('http://test/sse', { method: 'GET' }));
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type') ?? '').toContain('text/event-stream');
+  if (!res.body) throw new Error('SSE response missing body');
+  const reader = new SseReader(res.body);
+  const endpointEv = await reader.next();
+  expect(endpointEv.event).toBe('endpoint');
+  const url = new URL(endpointEv.data, 'http://test');
+  const sessionId = url.searchParams.get('sessionId');
+  expect(sessionId).toMatch(/^[0-9a-f-]{36}$/);
+  return { reader, sessionId: sessionId as string, res };
+}
+
+async function sendMessage(
+  app: Hono,
+  sessionId: string,
+  message: JSONRPCMessage,
+): Promise<Response> {
+  return app.fetch(
+    new Request(`http://test/messages?sessionId=${encodeURIComponent(sessionId)}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(message),
+    }),
+  );
+}
+
+describe('HonoSseTransport', () => {
+  test('opens SSE, announces endpoint, completes initialize handshake', async () => {
+    const app = buildTestApp();
+    const { reader, sessionId } = await openSse(app);
+
+    const initReq: JSONRPCMessage = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'sse-test-client', version: '0' },
+      },
+    } as JSONRPCMessage;
+    const postRes = await sendMessage(app, sessionId, initReq);
+    expect(postRes.status).toBe(202);
+
+    const initRespEv = await reader.next();
+    expect(initRespEv.event).toBe('message');
+    const initResp = JSON.parse(initRespEv.data) as {
+      id?: number;
+      result?: { serverInfo?: { name?: string } };
+    };
+    expect(initResp.id).toBe(1);
+    expect(initResp.result?.serverInfo?.name).toBe('aula-mcp-test');
+
+    await reader.close();
+  });
+
+  test('tools/list returns the echo tool after initialize', async () => {
+    const app = buildTestApp();
+    const { reader, sessionId } = await openSse(app);
+
+    await sendMessage(app, sessionId, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'sse-test-client', version: '0' },
+      },
+    } as JSONRPCMessage);
+    await reader.next(); // initialize response
+
+    await sendMessage(app, sessionId, {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+      params: {},
+    } as JSONRPCMessage);
+
+    await sendMessage(app, sessionId, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+    } as JSONRPCMessage);
+
+    const listEv = await reader.next();
+    expect(listEv.event).toBe('message');
+    const listResp = JSON.parse(listEv.data) as {
+      id?: number;
+      result?: { tools?: Array<{ name: string }> };
+    };
+    expect(listResp.id).toBe(2);
+    const toolNames = (listResp.result?.tools ?? []).map((t) => t.name);
+    expect(toolNames).toContain('echo');
+
+    await reader.close();
+  });
+
+  test('tools/call round-trips through SSE', async () => {
+    const app = buildTestApp();
+    const { reader, sessionId } = await openSse(app);
+
+    await sendMessage(app, sessionId, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'sse-test-client', version: '0' },
+      },
+    } as JSONRPCMessage);
+    await reader.next();
+    await sendMessage(app, sessionId, {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+      params: {},
+    } as JSONRPCMessage);
+
+    await sendMessage(app, sessionId, {
+      jsonrpc: '2.0',
+      id: 99,
+      method: 'tools/call',
+      params: { name: 'echo', arguments: { msg: 'hej fra HA' } },
+    } as JSONRPCMessage);
+
+    const callEv = await reader.next();
+    const callResp = JSON.parse(callEv.data) as {
+      id?: number;
+      result?: { content?: Array<{ type: string; text?: string }> };
+    };
+    expect(callResp.id).toBe(99);
+    expect(callResp.result?.content?.[0]?.text).toBe('hej fra HA');
+
+    await reader.close();
+  });
+
+  test('POST to /messages with unknown sessionId returns 404', async () => {
+    const app = buildTestApp();
+    const res = await sendMessage(app, '00000000-0000-0000-0000-000000000000', {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {},
+    } as JSONRPCMessage);
+    expect(res.status).toBe(404);
+  });
+
+  test('POST to /messages without sessionId returns 400', async () => {
+    const app = buildTestApp();
+    const res = await app.fetch(
+      new Request('http://test/messages', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test('concurrent SSE sessions get distinct ids and isolated tool calls', async () => {
+    const app = buildTestApp();
+    const a = await openSse(app);
+    const b = await openSse(app);
+    expect(a.sessionId).not.toBe(b.sessionId);
+
+    for (const { sessionId, reader } of [a, b]) {
+      await sendMessage(app, sessionId, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'sse-test-client', version: '0' },
+        },
+      } as JSONRPCMessage);
+      await reader.next();
+      await sendMessage(app, sessionId, {
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+        params: {},
+      } as JSONRPCMessage);
+    }
+
+    // A's call should resolve only on A's stream, B's only on B's.
+    await sendMessage(app, a.sessionId, {
+      jsonrpc: '2.0',
+      id: 10,
+      method: 'tools/call',
+      params: { name: 'echo', arguments: { msg: 'from-a' } },
+    } as JSONRPCMessage);
+    const aResp = await a.reader.next();
+    const aPayload = JSON.parse(aResp.data) as { result?: { content?: Array<{ text?: string }> } };
+    expect(aPayload.result?.content?.[0]?.text).toBe('from-a');
+
+    await sendMessage(app, b.sessionId, {
+      jsonrpc: '2.0',
+      id: 20,
+      method: 'tools/call',
+      params: { name: 'echo', arguments: { msg: 'from-b' } },
+    } as JSONRPCMessage);
+    const bResp = await b.reader.next();
+    const bPayload = JSON.parse(bResp.data) as { result?: { content?: Array<{ text?: string }> } };
+    expect(bPayload.result?.content?.[0]?.text).toBe('from-b');
+
+    await a.reader.close();
+    await b.reader.close();
+  });
+});

--- a/packages/mcp-server/src/sse-transport.ts
+++ b/packages/mcp-server/src/sse-transport.ts
@@ -1,0 +1,103 @@
+/**
+ * Hono-native MCP SSE transport.
+ *
+ * The MCP SDK ships an `SSEServerTransport`, but it's Node-only (built on
+ * `http.IncomingMessage`/`ServerResponse`) and marked deprecated in favour of
+ * Streamable HTTP. Home Assistant's official MCP client integration still
+ * speaks the legacy SSE transport, so we ship a Hono/Bun-compatible
+ * implementation here.
+ *
+ * Legacy SSE transport protocol:
+ *   1. Client GETs `/sse` and keeps the connection open.
+ *   2. Server's FIRST SSE event MUST be `event: endpoint` whose data is the
+ *      URI the client should POST subsequent messages to (including the
+ *      sessionId query parameter that ties POSTs back to this stream).
+ *   3. Client POSTs JSON-RPC messages to `/messages?sessionId=…`.
+ *   4. Server pushes JSON-RPC responses as `event: message` events on the
+ *      held-open SSE stream.
+ *
+ * One SSE connection = one transport instance = one MCP server session.
+ */
+
+import type {
+  Transport,
+  TransportSendOptions,
+} from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { JSONRPCMessage, MessageExtraInfo } from '@modelcontextprotocol/sdk/types.js';
+import type { SSEStreamingApi } from 'hono/streaming';
+
+export interface HonoSseTransportOptions {
+  sessionId: string;
+  /** Path the client should POST follow-up messages to. */
+  messageEndpoint: string;
+  stream: SSEStreamingApi;
+}
+
+export class HonoSseTransport implements Transport {
+  readonly sessionId: string;
+
+  onmessage?: <T extends JSONRPCMessage>(message: T, extra?: MessageExtraInfo) => void;
+  onclose?: () => void;
+  onerror?: (err: Error) => void;
+
+  private readonly stream: SSEStreamingApi;
+  private readonly messageEndpoint: string;
+  private closed = false;
+  private started = false;
+
+  constructor(opts: HonoSseTransportOptions) {
+    this.sessionId = opts.sessionId;
+    this.stream = opts.stream;
+    this.messageEndpoint = opts.messageEndpoint;
+  }
+
+  async start(): Promise<void> {
+    if (this.started) {
+      // The SDK calls start() implicitly via Server.connect(); calling it
+      // twice is a programming error, not a runtime condition.
+      throw new Error('HonoSseTransport.start() called twice');
+    }
+    this.started = true;
+    const url = `${this.messageEndpoint}?sessionId=${encodeURIComponent(this.sessionId)}`;
+    await this.stream.writeSSE({ event: 'endpoint', data: url });
+  }
+
+  async send(message: JSONRPCMessage, _options?: TransportSendOptions): Promise<void> {
+    if (this.closed || this.stream.aborted || this.stream.closed) return;
+    await this.stream.writeSSE({ event: 'message', data: JSON.stringify(message) });
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    if (!this.stream.closed && !this.stream.aborted) {
+      try {
+        await this.stream.close();
+      } catch {
+        // Stream may already be torn down by the runtime; nothing to do.
+      }
+    }
+    this.onclose?.();
+  }
+
+  /**
+   * Feed a JSON-RPC message that arrived via POST /messages into the
+   * transport's onmessage callback. Called by the route handler.
+   */
+  receive(message: JSONRPCMessage, extra?: MessageExtraInfo): void {
+    if (this.closed) {
+      this.onerror?.(new Error('Received message on closed SSE transport'));
+      return;
+    }
+    if (!this.onmessage) {
+      // The Transport interface explicitly warns about this race: "This
+      // method should only be called after callbacks are installed, or
+      // else messages may be lost." McpServer.connect() installs the
+      // handler before transport.start() resolves, so in practice this
+      // only fires on truly out-of-order traffic.
+      this.onerror?.(new Error('Received message before onmessage handler installed'));
+      return;
+    }
+    this.onmessage(message, extra);
+  }
+}


### PR DESCRIPTION
## Summary

Adds the legacy MCP **SSE transport** as a second route group on the Hono server, so `aula-mcp` can be consumed by clients that haven't moved to Streamable HTTP yet — most notably Home Assistant's official [`mcp` (client) integration](https://www.home-assistant.io/integrations/mcp/) (shipped in HA 2025.2).

End state for the HA-runner story: point the HA MCP client integration at `http://<ha-host>:7878/sse`, and Assist + your chosen LLM (Anthropic / OpenAI / Ollama) gets every `aula.*` tool callable — including via Voice.

## New routes

| Route | Purpose |
| --- | --- |
| `GET /sse` | Opens an SSE stream. First event is the spec-required `endpoint` announce telling the client where to POST. One stream = one McpServer instance = one session. |
| `POST /messages?sessionId=…` | Client→server channel for the session selected by query param. Server responds 202 Accepted; the JSON-RPC response itself is delivered over the SSE stream. |

The existing `/mcp` routes (Streamable HTTP) and `server-stdio.ts` are untouched.

## Why a hand-rolled transport

The MCP SDK ships `SSEServerTransport`, but it's Node-only (`http.IncomingMessage`/`ServerResponse`) and marked `@deprecated`. Hono on Bun uses Web Standard streams, so the SDK transport can't be wired up here without an adapter shim. Implementing the `Transport` interface (`start/send/close` + `onmessage`/`onclose`/`onerror`) on top of `hono/streaming`'s `streamSSE` is ~100 lines and avoids the shim.

## Per-connection wiring

`McpServer.connect()` binds a single transport, so each `GET /sse` instantiates a fresh `McpServer`. Multiple simultaneous clients (e.g. HA + Claude Desktop on the same LAN) get isolated sessions. `AulaContext` is cheap to construct — it just lazily wraps the shared token store on first call — so per-session duplication is fine for single-user LAN deployments.

## Tests

In-process via `app.fetch()` (no `Bun.serve`, no real network). Covers:

- SSE handshake announces the endpoint event with a session id
- `initialize` round-trip — POST request → response delivered over SSE
- `tools/list` after initialize
- `tools/call` with arguments — verifies bidirectional flow end-to-end
- `POST /messages` without `sessionId` → 400
- `POST /messages` with unknown `sessionId` → 404
- Two concurrent SSE sessions get distinct ids; tool calls on one don't leak to the other

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `bun test` — 223 pass, 1 skip, 0 fail (217 existing + 6 new SSE)
- [x] `pnpm lint` — no new findings (3 pre-existing infos in `integrations.test.ts` from PR #8, unrelated)
- [ ] End-to-end against HA: install HA's `mcp` client integration, point at `http://aula-mcp.local:7878/sse`, verify Assist sees the `aula.*` tools (needs PR 2 — the HA addon — to be a one-click flow).

## Follow-up

This is PR 1 of 2. PR 2 packages aula-mcp as a Home Assistant add-on (Dockerfile + `config.yaml` + `repository.yaml`) so HA users install it from the addon store with one click. Deferred from this PR: OAuth on the MCP endpoint (LAN binding is sufficient for v0) and submission to HA's official addons registry (user-added repo is the lighter first step).