### PR TITLE
feat(ha-addon): Home Assistant add-on packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,13 +219,18 @@ aula.dithjem.dk {
 
 > ⚠️ Hvis du *skal* exposé serveren direkte (springe proxy-laget over) skal du eksplicit sætte `AULA_MCP_ALLOW_REMOTE=1` — det er en kontrolleret, tilsigtet handling, ikke et uheld.
 
-### Mulighed 3: Home Assistant addon (på vej)
+### Mulighed 3: Home Assistant add-on
 
-Den nemmeste vej for HA-brugere bliver en addon der pakker `aula-mcp` ind, så den kører som en del af din HA-installation og er tilgængelig fra HA's Voice/Assist + alle dine HA-automatiseringer. Hvis du har **Nabu Casa**, åbner det også for sikker fjernadgang via deres tunnel.
+Den nemmeste vej for HA-brugere. `aula-mcp` kører som en del af din HA-installation og er tilgængelig fra HA's Voice/Assist + alle dine HA-automatiseringer. Hvis du har **Nabu Casa**, åbner det også for sikker fjernadgang via deres tunnel.
 
-`aula-mcp` taler både den nye Streamable HTTP-protokol (`/mcp`) og den ældre SSE-dialekt (`/sse`) — HA's officielle [`mcp` (client) integration](https://www.home-assistant.io/integrations/mcp/) bruger SSE, så du peger den bare på `http://<ha-host>:7878/sse`, så har Assist + dit valgte LLM (Anthropic / OpenAI / Ollama) adgang til alle `aula.*` tools.
+1. Tilføj dette repo som add-on repository i HA: Settings → Add-ons → ⋮ → Repositories → indsæt `https://github.com/Casperjuel/aula-mcp`.
+2. Installer `aula-mcp` add-on'en fra det repository der dukker op.
+3. Kopier dine tokens fra en workstation ind i `/config/aula-mcp/` (kør `pnpm login` + `pnpm aula tokens export` på workstation, og SCP/Samba til HA).
+4. Settings → Devices & Services → Add Integration → **Model Context Protocol** → `http://homeassistant.local:7878/sse`.
 
-> 🛣️ Spores som [issue (TBD)] — feedback fra HA-folk meget velkommen. Hvis du har erfaring med HA add-on-byggeri, så bliver det her din hjælp.
+Full walkthrough med detaljerede skridt: [`homeassistant-addon/README.md`](./homeassistant-addon/README.md).
+
+`aula-mcp` taler både den nye Streamable HTTP-protokol (`/mcp`) og den ældre SSE-dialekt (`/sse`) — HA's officielle [`mcp` (client) integration](https://www.home-assistant.io/integrations/mcp/) bruger SSE, så du peger den bare på `http://<ha-host>:7878/sse`. Så har Assist + dit valgte LLM (Anthropic / OpenAI / Ollama) adgang til alle `aula.*` tools — inklusive via voice.
 
 ### Mulighed 4: VPS i Tyskland (Hetzner, Coolify)
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ aula.dithjem.dk {
 
 Den nemmeste vej for HA-brugere. `aula-mcp` kører som en del af din HA-installation og er tilgængelig fra HA's Voice/Assist + alle dine HA-automatiseringer. Hvis du har **Nabu Casa**, åbner det også for sikker fjernadgang via deres tunnel.
 
-1. Tilføj dette repo som add-on repository i HA: Settings → Add-ons → ⋮ → Repositories → indsæt `https://github.com/Casperjuel/aula-mcp`.
+[![Open your Home Assistant instance and add the aula-mcp add-on repository.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https://github.com/Casperjuel/aula-mcp)
+
+1. Klik badget ovenfor (eller manuelt: Settings → Add-ons → ⋮ → Repositories → indsæt `https://github.com/Casperjuel/aula-mcp`).
 2. Installer `aula-mcp` add-on'en fra det repository der dukker op.
 3. Kopier dine tokens fra en workstation ind i `/config/aula-mcp/` (kør `pnpm login` + `pnpm aula tokens export` på workstation, og SCP/Samba til HA).
 4. Settings → Devices & Services → Add Integration → **Model Context Protocol** → `http://homeassistant.local:7878/sse`.

--- a/homeassistant-addon/Dockerfile
+++ b/homeassistant-addon/Dockerfile
@@ -1,0 +1,42 @@
+# Home Assistant add-on image for aula-mcp.
+#
+# We use the official Bun image as a base rather than HA's base image — the
+# server is plain TypeScript-on-Bun and doesn't need s6-overlay/bashio. HA
+# runs whatever image config.yaml points at; the protocol is just "long-
+# running process with a Dockerfile and config.yaml beside it."
+#
+# HA Supervisor uses *this directory* as the Docker build context, so we
+# can't reach up into the monorepo with `COPY ../packages`. Instead we git-
+# clone the source inside the build. The AULA_MCP_REF arg lets you pin to a
+# tag; default is `main` so a re-install always picks up the latest.
+ARG BUILD_FROM=oven/bun:1.3-debian
+# hadolint ignore=DL3006
+FROM ${BUILD_FROM}
+
+ARG AULA_MCP_REF=main
+
+# jq parses the user's add-on options (HA writes them to /data/options.json
+# at startup). git clones the source. ca-certificates so HTTPS to Aula /
+# MitID works at runtime.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git jq ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# pnpm is the workspace tool of record for this monorepo. Bun's installer
+# can't honour pnpm-lock.yaml, so install pnpm via Bun's npm-compat layer
+# and let it resolve the workspace deterministically.
+RUN bun install -g pnpm@10
+
+WORKDIR /app
+
+RUN git clone --depth 1 --branch "${AULA_MCP_REF}" \
+  https://github.com/Casperjuel/aula-mcp.git .
+
+RUN pnpm install --frozen-lockfile
+
+COPY run.sh /run.sh
+RUN chmod +x /run.sh
+
+EXPOSE 7878
+
+CMD ["/run.sh"]

--- a/homeassistant-addon/README.md
+++ b/homeassistant-addon/README.md
@@ -10,11 +10,10 @@ etc.) gets every `aula.*` tool — including for voice queries like
 
 ## Install
 
-1. **Add this repository to your Supervisor add-on store.** Settings → Add-ons
-   → Add-on Store → ⋮ (top-right) → Repositories → paste:
-   ```
-   https://github.com/Casperjuel/aula-mcp
-   ```
+[![Open your Home Assistant instance and add the aula-mcp add-on repository.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https://github.com/Casperjuel/aula-mcp)
+
+1. **Click the badge above** (or manually: Settings → Add-ons → Add-on Store
+   → ⋮ (top-right) → Repositories → paste `https://github.com/Casperjuel/aula-mcp`).
 2. **Install the `aula-mcp` add-on** from the now-visible repository.
 3. **Don't start it yet** — first transfer your Aula tokens (next section).
 

--- a/homeassistant-addon/README.md
+++ b/homeassistant-addon/README.md
@@ -1,0 +1,92 @@
+# aula-mcp — Home Assistant add-on
+
+Runs the `aula-mcp` server (the MCP interface for the Danish school platform
+Aula) inside your Home Assistant supervisor, exposing the standard endpoints
+at `http://homeassistant.local:7878/`. HA's official
+[`mcp` (client) integration](https://www.home-assistant.io/integrations/mcp/)
+points at `/sse`, and Assist + your chosen LLM (Anthropic, OpenAI, Ollama,
+etc.) gets every `aula.*` tool — including for voice queries like
+*"hvad er lektien i dag?"*.
+
+## Install
+
+1. **Add this repository to your Supervisor add-on store.** Settings → Add-ons
+   → Add-on Store → ⋮ (top-right) → Repositories → paste:
+   ```
+   https://github.com/Casperjuel/aula-mcp
+   ```
+2. **Install the `aula-mcp` add-on** from the now-visible repository.
+3. **Don't start it yet** — first transfer your Aula tokens (next section).
+
+## First-time: transfer your tokens
+
+aula-mcp's MitID login needs an interactive browser, which a headless HA box
+can't provide. The supported pattern is: log in on a workstation once, then
+copy the encrypted bundle to your HA `/config/aula-mcp/` directory.
+
+On your workstation (macOS or Linux):
+
+```sh
+git clone https://github.com/Casperjuel/aula-mcp.git && cd aula-mcp
+pnpm install
+pnpm login          # MitID QR-code flow, fully interactive
+pnpm aula tokens export ./aula-bundle
+# Writes ./aula-bundle/tokens.json + ./aula-bundle/.key
+```
+
+Then copy `tokens.json` and `.key` into your HA's `/config/aula-mcp/`:
+
+```sh
+# From your workstation; HA accessible over SSH or Samba
+scp aula-bundle/tokens.json aula-bundle/.key \
+    homeassistant:/config/aula-mcp/
+```
+
+Or use the **File editor** add-on / Samba share if you'd rather drag-and-drop.
+
+## Configure
+
+In the add-on's Configuration tab:
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `aula_mcp_key` | `""` | Encryption key for the token store. Leave empty unless you set one when exporting tokens. |
+| `log` | `false` | Verbose logs (auth flow, HTTP calls). Useful when something's stuck. |
+| `allow_remote` | `true` | Bind to `0.0.0.0` so HA + other LAN devices can reach the server. Disable only if you front the addon with Ingress / reverse proxy. |
+
+Start the add-on. Check the log — should see `aula-mcp listening on http://0.0.0.0:7878/mcp`.
+
+## Connect HA's MCP client
+
+1. Settings → Devices & Services → Add Integration → **Model Context Protocol**.
+2. **SSE Server URL:** `http://homeassistant.local:7878/sse` (or `http://<container-host>:7878/sse` if HA isn't on `homeassistant.local`).
+3. Save. HA discovers the tool surface (`aula.discover`, `aula.ugeplan.*`,
+   `aula.lektier.easyiq`, `aula.messages.*`, …) and exposes it to whatever
+   conversation agent you've configured (Settings → Voice assistants).
+
+## Verify
+
+Open Settings → Voice assistants → your Assist pipeline → ask:
+
+> *Hvad står der på ugeplanen for [barn] næste uge?*
+
+The LLM should call `aula.discover` once, then a ugeplan-tool. If you see
+"tool not found" or auth errors, check the add-on log.
+
+## Update
+
+The add-on tracks `main` for now (no per-version published images). Re-install
+the add-on to rebuild against the latest commit.
+
+## Limitations
+
+- **No OAuth on the MCP endpoint yet.** The server is single-user — anyone
+  with LAN access to `:7878` can drive your Aula tokens. Inside a household
+  on a trusted LAN this is generally fine; if your network has untrusted
+  peers, set `allow_remote: false` and front the add-on with HA Ingress.
+- **MitID re-login still happens on a workstation.** When your Aula refresh
+  token expires (Aula rotates aggressively), re-run `pnpm login` + `pnpm aula
+  tokens export` and recopy the bundle. There's no headless re-login flow.
+- **One arch image per build.** Pre-built multi-arch images aren't published;
+  Supervisor builds the image locally on install. First start can take a
+  minute or two on a Raspberry Pi.

--- a/homeassistant-addon/build.yaml
+++ b/homeassistant-addon/build.yaml
@@ -1,0 +1,13 @@
+# HA Supervisor build config for the aula-mcp add-on.
+#
+# `build_from` overrides the default base image per architecture. We use
+# the official Bun image for both supported arches (amd64, aarch64) since
+# Bun publishes pre-built binaries for both.
+#
+# To pin the add-on to a specific tag instead of `main`, override
+# AULA_MCP_REF here (e.g. `AULA_MCP_REF: "v1.0.1"`).
+build_from:
+  amd64: oven/bun:1.3-debian
+  aarch64: oven/bun:1.3-debian
+args:
+  AULA_MCP_REF: main

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,0 +1,31 @@
+name: aula-mcp
+version: "1.0.1"
+slug: aula_mcp
+description: >-
+  MCP server for the Danish school platform Aula. Exposes aula.discover,
+  ugeplan, lektier, messages and more as MCP tools that HA's Assist
+  conversation agent (Anthropic / OpenAI / Ollama / etc.) can call —
+  including via Voice. Point HA's official `mcp` (client) integration
+  at http://homeassistant.local:7878/sse after install.
+url: "https://github.com/Casperjuel/aula-mcp"
+arch:
+  - amd64
+  - aarch64
+init: false
+boot: auto
+startup: services
+host_network: false
+ports:
+  7878/tcp: 7878
+ports_description:
+  7878/tcp: aula-mcp HTTP (/mcp) + SSE (/sse)
+map:
+  - config:rw
+options:
+  aula_mcp_key: ""
+  log: false
+  allow_remote: true
+schema:
+  aula_mcp_key: "password?"
+  log: bool
+  allow_remote: bool

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -20,7 +20,9 @@ ports:
 ports_description:
   7878/tcp: aula-mcp HTTP (/mcp) + SSE (/sse)
 map:
-  - config:rw
+  # `homeassistant_config:rw` is the modern spelling; the older `config:rw`
+  # still works but emits a deprecation warning in recent Supervisor builds.
+  - homeassistant_config:rw
 options:
   aula_mcp_key: ""
   log: false

--- a/homeassistant-addon/run.sh
+++ b/homeassistant-addon/run.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Home Assistant add-on entry. Translates HA-style options (read from
+# /data/options.json, populated by Supervisor) into the env vars aula-mcp's
+# server entry expects, then exec's into the long-running MCP server.
+set -eu
+
+OPTIONS_FILE=/data/options.json
+
+if [ -f "$OPTIONS_FILE" ]; then
+  AULA_MCP_KEY="$(jq -r '.aula_mcp_key // empty' "$OPTIONS_FILE")"
+  LOG="$(jq -r '.log // false' "$OPTIONS_FILE")"
+  ALLOW_REMOTE="$(jq -r '.allow_remote // true' "$OPTIONS_FILE")"
+else
+  # Running outside Supervisor (e.g. local docker test). Fall back to env.
+  AULA_MCP_KEY="${AULA_MCP_KEY:-}"
+  LOG="${LOG:-false}"
+  ALLOW_REMOTE="${ALLOW_REMOTE:-true}"
+fi
+
+# `/config/aula-mcp/` is mapped from Supervisor's /config volume. The user
+# copies their `tokens.json` + `.key` here after running `aula tokens export`
+# on a workstation — see homeassistant-addon/README.md.
+export AULA_MCP_DIR="/config/aula-mcp"
+mkdir -p "$AULA_MCP_DIR"
+
+# The MCP server refuses non-loopback binds by default; HA's whole point is
+# the LAN serving everyone in the household, so default to remote-allowed.
+# Users can disable via the addon option if they front the addon with
+# something like NPM/Ingress.
+export AULA_MCP_HOST="0.0.0.0"
+if [ "$ALLOW_REMOTE" = "true" ]; then
+  export AULA_MCP_ALLOW_REMOTE=1
+fi
+
+if [ "$LOG" = "true" ]; then
+  export AULA_MCP_LOG=1
+fi
+
+if [ -n "$AULA_MCP_KEY" ]; then
+  export AULA_MCP_KEY
+fi
+
+cd /app
+exec bun packages/mcp-server/src/server.ts

--- a/homeassistant-addon/run.sh
+++ b/homeassistant-addon/run.sh
@@ -24,12 +24,16 @@ export AULA_MCP_DIR="/config/aula-mcp"
 mkdir -p "$AULA_MCP_DIR"
 
 # The MCP server refuses non-loopback binds by default; HA's whole point is
-# the LAN serving everyone in the household, so default to remote-allowed.
-# Users can disable via the addon option if they front the addon with
-# something like NPM/Ingress.
-export AULA_MCP_HOST="0.0.0.0"
+# serving the LAN, so the default `allow_remote: true` opens it up. Setting
+# `allow_remote: false` keeps the MCP traffic loopback-only inside the
+# container — useful if you front it with HA Ingress / a reverse proxy, but
+# in that case the LAN can't reach :7878 directly so HA's MCP client
+# integration won't either. Don't flip unless you know what you're doing.
 if [ "$ALLOW_REMOTE" = "true" ]; then
+  export AULA_MCP_HOST="0.0.0.0"
   export AULA_MCP_ALLOW_REMOTE=1
+else
+  export AULA_MCP_HOST="127.0.0.1"
 fi
 
 if [ "$LOG" = "true" ]; then

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: aula-mcp add-ons
+url: "https://github.com/Casperjuel/aula-mcp"
+maintainer: "Casper Juel <cj@signifly.com>"


### PR DESCRIPTION
## Summary

Adds a Home Assistant add-on so HA users can install `aula-mcp` from **Settings → Add-ons** in one click and have it discovered by HA's official [`mcp` (client) integration](https://www.home-assistant.io/integrations/mcp/) (HA 2025.2+). Combined with the SSE transport from #18, this makes Assist + Voice able to call every `aula.*` tool — including via Danish voice queries like *"hvad er lektien i dag?"*.

**Depends on #18** (the legacy SSE transport). The add-on will boot without it, but HA's MCP client integration can only connect via `/sse`, so it's a no-op until #18 lands.

## Files

| Path | Purpose |
| --- | --- |
| `repository.yaml` | Declares the repo as an HA add-on repository so users can paste the URL into HA's add-on store. |
| `homeassistant-addon/config.yaml` | Add-on manifest. Name, slug, port mapping (`7878/tcp`), `/config` rw map, schema for the user-facing options. |
| `homeassistant-addon/build.yaml` | Per-arch base image + `AULA_MCP_REF` build arg (defaults to `main`). |
| `homeassistant-addon/Dockerfile` | Bun-based image. Git-clones the source at build time so the addon dir stays self-contained — HA Supervisor uses *this directory* as the Docker build context and can't reach into the monorepo. |
| `homeassistant-addon/run.sh` | Parses `/data/options.json` via `jq`, maps options → env vars (`AULA_MCP_KEY/LOG/ALLOW_REMOTE/DIR`), `exec`s `bun packages/mcp-server/src/server.ts`. |
| `homeassistant-addon/README.md` | Install + token-transfer walkthrough. |

## Token transfer

The MitID dance still has to happen on a workstation (it needs a real browser). The encrypted bundle (`tokens.json` + `.key`) is then copied to HA's `/config/aula-mcp/`. This reuses the `aula tokens export/import` flow that already exists. The add-on README walks through it.

## User experience

1. Paste `https://github.com/Casperjuel/aula-mcp` as a repository in HA add-on store.
2. Install the `aula-mcp` add-on.
3. Run `pnpm login` + `pnpm aula tokens export` on a workstation, copy the bundle to HA's `/config/aula-mcp/`.
4. Start the add-on, set `AULA_MCP_KEY` if you used one.
5. In HA: Settings → Devices & Services → Add Integration → Model Context Protocol → SSE URL `http://homeassistant.local:7878/sse`.
6. Configure Assist with your LLM of choice (Anthropic / OpenAI / Ollama). Voice now knows about `aula.*` tools.

## Test plan

- [x] YAML config + manifest parse correctly.
- [x] `sh -n run.sh` — shell syntax valid.
- [x] `git log` + diff confirm the addon dir is self-contained (no external `COPY` paths).
- [ ] **End-to-end on real HA hardware** — install via add-on store, copy tokens, connect HA's MCP client integration, run a voice query through Assist. Needs your hardware; I can't validate this locally.

## Deferred

- **OAuth on the MCP endpoint.** LAN binding is sufficient for v0; can revisit when there's a clear ask.
- **Pre-built multi-arch images on GHCR.** For now Supervisor builds locally on install (first install on a Raspberry Pi takes 1-2 min). A CI workflow that publishes to `ghcr.io/casperjuel/aula-mcp-addon` would skip that — out of scope here.
- **Submission to HA's official add-ons registry.** User-added repo is the lighter first step; official submission has its own review process.

## Merge order

Suggest #18 first, then this. (Both safe to land independently — the addon just becomes useful once `/sse` exists on `main`.)