### PR TITLE
feat(ha-addon): in-addon MitID login UI via HA Ingress

### DIFF
--- a/homeassistant-addon/README.md
+++ b/homeassistant-addon/README.md
@@ -17,31 +17,38 @@ etc.) gets every `aula.*` tool — including for voice queries like
 2. **Install the `aula-mcp` add-on** from the now-visible repository.
 3. **Don't start it yet** — first transfer your Aula tokens (next section).
 
-## First-time: transfer your tokens
+## First-time: log in via the add-on's web UI
 
-aula-mcp's MitID login needs an interactive browser, which a headless HA box
-can't provide. The supported pattern is: log in on a workstation once, then
-copy the encrypted bundle to your HA `/config/aula-mcp/` directory.
+1. Start the add-on.
+2. Open the **aula-mcp** entry in your HA sidebar (added automatically via the
+   add-on's Ingress panel). You should see *"Ikke logget ind"*.
+3. Type your **MitID username** and click **Start login**.
+4. Two QR codes appear. Open your **MitID app**, scan either of them (they
+   alternate as an anti-phishing check), and approve the login on your phone.
+5. If MitID returns multiple identities (rare — typically only parents with
+   several login routes), pick the one your school knows you by.
+6. On success the page flips to *"Logget ind"* and the tokens are persisted
+   encrypted in `/config/aula-mcp/` automatically.
 
-On your workstation (macOS or Linux):
+The whole flow happens inside HA's Ingress proxy — your browser never leaves
+the HA UI, and the MitID-app talks to nemlog-in.dk directly. The add-on only
+sees the resulting OAuth tokens.
+
+### Fallback: workstation export
+
+If you'd rather not type your MitID username into HA's UI (or you're hardening
+a setup with no browser access), the original workstation flow still works:
 
 ```sh
 git clone https://github.com/Casperjuel/aula-mcp.git && cd aula-mcp
 pnpm install
-pnpm login          # MitID QR-code flow, fully interactive
-pnpm aula tokens export ./aula-bundle
-# Writes ./aula-bundle/tokens.json + ./aula-bundle/.key
+pnpm login                                 # MitID QR-code flow on workstation
+pnpm aula tokens export ./aula-bundle      # writes tokens.json + .key
+scp aula-bundle/tokens.json aula-bundle/.key homeassistant:/config/aula-mcp/
 ```
 
-Then copy `tokens.json` and `.key` into your HA's `/config/aula-mcp/`:
-
-```sh
-# From your workstation; HA accessible over SSH or Samba
-scp aula-bundle/tokens.json aula-bundle/.key \
-    homeassistant:/config/aula-mcp/
-```
-
-Or use the **File editor** add-on / Samba share if you'd rather drag-and-drop.
+The encrypted bundle is interchangeable — the add-on picks it up on next
+restart regardless of which path produced it.
 
 ## Configure
 

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -23,6 +23,14 @@ map:
   # `homeassistant_config:rw` is the modern spelling; the older `config:rw`
   # still works but emits a deprecation warning in recent Supervisor builds.
   - homeassistant_config:rw
+# In-addon login UI exposed via HA Ingress. The addon binds two ports:
+# - 7878 (above): MCP traffic, exposed to the LAN per `ports:`.
+# - 8099 (below): setup/login UI, only reachable through HA's Ingress proxy.
+#   `ingress_port` MUST stay in sync with AULA_MCP_INGRESS_PORT in run.sh.
+ingress: true
+ingress_port: 8099
+panel_icon: mdi:school
+panel_title: aula-mcp
 options:
   aula_mcp_key: ""
   log: false

--- a/homeassistant-addon/run.sh
+++ b/homeassistant-addon/run.sh
@@ -36,6 +36,10 @@ else
   export AULA_MCP_HOST="127.0.0.1"
 fi
 
+# Boot the in-addon setup/login UI on the port HA Ingress proxies to.
+# config.yaml's `ingress_port` MUST stay in sync with this value.
+export AULA_MCP_INGRESS_PORT=8099
+
 if [ "$LOG" = "true" ]; then
   export AULA_MCP_LOG=1
 fi

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -20,6 +20,10 @@
     "@aula-mcp/aula-client": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "hono": "^4.12.18",
+    "qrcode": "^1.5.4",
     "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/qrcode": "^1.5.6"
   }
 }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -16,7 +16,7 @@
  * different transport.
  *
  * Env:
- *   AULA_MCP_PORT             — port to bind (default 7878)
+ *   AULA_MCP_PORT             — port to bind for MCP traffic (default 7878)
  *   AULA_MCP_HOST             — interface to bind (default 127.0.0.1)
  *   AULA_MCP_DIR              — config dir (default ~/.config/aula-mcp)
  *   AULA_MCP_KEY              — encryption key for the token store
@@ -29,6 +29,9 @@
  *                               GET /sse requests get 503'd (default 16)
  *   AULA_MCP_SSE_IDLE_MS      — evict /sse sessions idle for >this many ms
  *                               (default 300_000 = 5 min)
+ *   AULA_MCP_INGRESS_PORT     — if set, also boots the in-addon setup/login UI
+ *                               on this port (bound to 0.0.0.0 for HA Ingress).
+ *                               Default unset; the HA addon sets it to 8099.
  */
 
 import { consoleLogger, silentLogger } from '@aula-mcp/aula-auth';
@@ -36,6 +39,7 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import { createMcpApp, type McpApp } from './setup.ts';
+import { createSetupApp } from './setup-ui.ts';
 import { HonoSseTransport } from './sse-transport.ts';
 
 const PORT = Number(process.env.AULA_MCP_PORT ?? 7878);
@@ -224,6 +228,33 @@ const server = Bun.serve({
   fetch: app.fetch,
 });
 
+// Optional in-addon setup/login UI. The HA addon sets AULA_MCP_INGRESS_PORT
+// to 8099; HA Supervisor proxies its Ingress traffic to that port, giving
+// users a one-click login flow inside HA's sidebar. Skipped when unset so
+// non-addon deployments (CLI workstation, VPS) don't open an extra port.
+let setupServer: ReturnType<typeof Bun.serve> | null = null;
+const INGRESS_PORT_RAW = process.env.AULA_MCP_INGRESS_PORT;
+if (INGRESS_PORT_RAW) {
+  const ingressPort = Number(INGRESS_PORT_RAW);
+  if (!Number.isInteger(ingressPort) || ingressPort <= 0) {
+    process.stderr.write(`AULA_MCP_INGRESS_PORT="${INGRESS_PORT_RAW}" is not a valid port.\n`);
+    process.exit(2);
+  }
+  const setupApp = createSetupApp({ logger });
+  setupServer = Bun.serve({
+    port: ingressPort,
+    // HA Ingress proxies from the Supervisor host *to* this port, so bind on
+    // all interfaces — the addon container's network namespace already isolates
+    // the port from the LAN unless config.yaml exposes it via `ports:`.
+    hostname: '0.0.0.0',
+    fetch: setupApp.fetch,
+  });
+  logger.info('aula-mcp.setup_ui.listening', { port: ingressPort });
+  process.stdout.write(
+    `aula-mcp setup UI listening on http://0.0.0.0:${ingressPort}/ (HA Ingress)\n`,
+  );
+}
+
 // Graceful shutdown — finish in-flight requests before exiting.
 let shuttingDown = false;
 async function shutdown(signal: NodeJS.Signals): Promise<void> {
@@ -239,6 +270,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
       Array.from(sseSessions.keys()).map((sid) => closeSseSession(sid, 'shutdown')),
     );
     await server.stop();
+    if (setupServer) await setupServer.stop();
     await mcp.close();
   } catch (err) {
     logger.error('aula-mcp.shutdown_error', { error: (err as Error).message });

--- a/packages/mcp-server/src/setup-ui.test.ts
+++ b/packages/mcp-server/src/setup-ui.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Route-shape tests for the in-addon setup/login UI. We don't drive a real
+ * MitID login here (that would need a network mock plus the real Aula
+ * fixtures and is the domain of the integration suite); we just pin the
+ * routes' contracts so a refactor can't silently change them.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { StoredTokenRecord, TokenStore } from '@aula-mcp/aula-auth';
+import { createSetupApp } from './setup-ui.ts';
+
+class MemoryStore implements TokenStore {
+  private record: StoredTokenRecord | null = null;
+  async load(): Promise<StoredTokenRecord | null> {
+    return this.record;
+  }
+  async save(record: StoredTokenRecord): Promise<void> {
+    this.record = record;
+  }
+  async clear(): Promise<void> {
+    this.record = null;
+  }
+}
+
+const SAMPLE_RECORD: StoredTokenRecord = {
+  version: 1,
+  username: 'demo',
+  tokens: {
+    access_token: 'AT',
+    refresh_token: 'RT',
+    token_type: 'Bearer',
+    expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    obtained_at: Math.floor(Date.now() / 1000),
+  },
+  saved_at: Math.floor(Date.now() / 1000),
+};
+
+describe('createSetupApp', () => {
+  test('GET / serves the login HTML', async () => {
+    const app = createSetupApp({ store: new MemoryStore() });
+    const res = await app.fetch(new Request('http://test/'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type') ?? '').toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain('aula-mcp');
+    // The page wires up EventSource for SSE — pin that so a refactor
+    // can't accidentally remove it.
+    expect(body).toContain('EventSource');
+    expect(body).toContain('login/start');
+  });
+
+  test('GET /status reports not logged in when store is empty', async () => {
+    const app = createSetupApp({ store: new MemoryStore() });
+    const res = await app.fetch(new Request('http://test/status'));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { logged_in: boolean };
+    expect(body.logged_in).toBe(false);
+  });
+
+  test('GET /status reports current token state when store has a record', async () => {
+    const store = new MemoryStore();
+    await store.save(SAMPLE_RECORD);
+    const app = createSetupApp({ store });
+    const res = await app.fetch(new Request('http://test/status'));
+    const body = (await res.json()) as {
+      logged_in: boolean;
+      username: string;
+      seconds_remaining: number;
+    };
+    expect(body.logged_in).toBe(true);
+    expect(body.username).toBe('demo');
+    expect(body.seconds_remaining).toBeGreaterThan(0);
+  });
+
+  test('POST /login/start rejects missing username', async () => {
+    const app = createSetupApp({ store: new MemoryStore() });
+    const res = await app.fetch(
+      new Request('http://test/login/start', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /login/start with invalid JSON returns 400', async () => {
+    const app = createSetupApp({ store: new MemoryStore() });
+    const res = await app.fetch(
+      new Request('http://test/login/start', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{not json',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /login/events without sessionId returns 400', async () => {
+    const app = createSetupApp({ store: new MemoryStore() });
+    const res = await app.fetch(new Request('http://test/login/events'));
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /login/events with unknown sessionId returns 404', async () => {
+    const app = createSetupApp({ store: new MemoryStore() });
+    const res = await app.fetch(
+      new Request('http://test/login/events?sessionId=00000000-0000-0000-0000-000000000000'),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test('POST /login/identity without sessionId returns 400', async () => {
+    const app = createSetupApp({ store: new MemoryStore() });
+    const res = await app.fetch(
+      new Request('http://test/login/identity', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ index: 0 }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /logout clears the store', async () => {
+    const store = new MemoryStore();
+    await store.save(SAMPLE_RECORD);
+    const app = createSetupApp({ store });
+    const res = await app.fetch(new Request('http://test/logout', { method: 'POST' }));
+    expect(res.status).toBe(200);
+    expect(await store.load()).toBeNull();
+  });
+});

--- a/packages/mcp-server/src/setup-ui.ts
+++ b/packages/mcp-server/src/setup-ui.ts
@@ -26,6 +26,7 @@
  * aren't useful and aren't supported.
  */
 
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
   AulaHttpClient,
@@ -41,6 +42,11 @@ import { Hono } from 'hono';
 import { type SSEStreamingApi, streamSSE } from 'hono/streaming';
 import QRCode from 'qrcode';
 
+/** Max time we'll hold a login session waiting on the user to pick their
+ *  MitID identity after the picker is shown. After this the login rejects
+ *  with a timeout so the session entry gets cleaned up instead of leaking. */
+const IDENTITY_PICK_TIMEOUT_MS = 5 * 60 * 1000;
+
 export interface SetupAppOptions {
   logger?: Logger;
   /** Override the token store (tests). Production uses the addon's
@@ -52,18 +58,20 @@ interface LoginSession {
   sessionId: string;
   username: string;
   stream?: SSEStreamingApi;
-  /** Resolves when the SSE stream is attached, so events posted before the
-   *  browser GETs /login/events get buffered + delivered. */
-  streamReady: Promise<SSEStreamingApi>;
-  resolveStream: (s: SSEStreamingApi) => void;
   /** Resolver waiting on user identity choice; null when no pending pick. */
   pendingIdentity: ((index: number) => void) | null;
   /** Queue of events that arrived before the stream was attached. */
   bufferedEvents: Array<{ event: string; data: string }>;
   abort: AbortController;
-  /** Set when the login resolves (success or error) so /login/events can
-   *  emit the terminal event and close cleanly. */
+  /** Set when the login resolves (success or error). The terminal event has
+   *  already been sent via `emit()` — this is just a flag so a late-attaching
+   *  SSE stream can replay it on connect. */
   terminal?: { event: 'success' | 'error'; data: string };
+  /** Resolves when runLogin has finished (after the terminal event has been
+   *  emitted). The SSE route handler awaits this instead of polling. */
+  done: Promise<void>;
+  /** Called by runLogin after the terminal event lands. */
+  signalDone: () => void;
 }
 
 const ICON_SVG = `<svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path d="M12 3 1 9l11 6 9-4.91V17h2V9z"/></svg>`;
@@ -102,18 +110,18 @@ export function createSetupApp(options: SetupAppOptions = {}): Hono {
     if (!username) return c.json({ error: 'username is required' }, 400);
 
     const sessionId = crypto.randomUUID();
-    let resolveStream!: (s: SSEStreamingApi) => void;
-    const streamReady = new Promise<SSEStreamingApi>((resolve) => {
-      resolveStream = resolve;
+    let signalDone!: () => void;
+    const done = new Promise<void>((resolve) => {
+      signalDone = resolve;
     });
     const session: LoginSession = {
       sessionId,
       username,
-      streamReady,
-      resolveStream,
       pendingIdentity: null,
       bufferedEvents: [],
       abort: new AbortController(),
+      done,
+      signalDone,
     };
     loginSessions.set(sessionId, session);
 
@@ -134,7 +142,6 @@ export function createSetupApp(options: SetupAppOptions = {}): Hono {
 
     return streamSSE(c, async (stream) => {
       session.stream = stream;
-      session.resolveStream(stream);
 
       // Drain any events buffered before the stream attached.
       for (const ev of session.bufferedEvents) {
@@ -142,39 +149,20 @@ export function createSetupApp(options: SetupAppOptions = {}): Hono {
       }
       session.bufferedEvents.length = 0;
 
-      // Replay terminal event if login already finished before the browser
-      // got here (shouldn't happen in practice — login takes seconds — but
-      // belt and suspenders).
-      if (session.terminal) {
-        await stream.writeSSE(session.terminal);
-        loginSessions.delete(sessionId);
-        return;
-      }
-
-      // Hold the stream open until the login finishes. The login emits
-      // events via session.stream.writeSSE directly; this promise resolves
-      // when the terminal event is sent.
-      await new Promise<void>((resolve) => {
+      // Hold the stream open until either the user disconnects or runLogin
+      // finishes. runLogin emits its terminal event via `emit()` (which now
+      // writes to this attached stream); we just need to wait for it to
+      // signal completion via `session.done`.
+      const aborted = new Promise<'aborted'>((resolve) => {
         stream.onAbort(() => {
           session.abort.abort();
-          loginSessions.delete(sessionId);
-          resolve();
+          resolve('aborted');
         });
-        // resolveOnTerminal hook installed by runLogin via session.terminal
-        const interval = setInterval(() => {
-          if (session.terminal) {
-            clearInterval(interval);
-            // Replay terminal in case it landed after the buffer drain.
-            session.stream
-              ?.writeSSE(session.terminal)
-              .catch(() => {})
-              .finally(() => {
-                loginSessions.delete(sessionId);
-                resolve();
-              });
-          }
-        }, 250);
       });
+      const finished = session.done.then(() => 'finished' as const);
+
+      await Promise.race([aborted, finished]);
+      loginSessions.delete(sessionId);
     });
   });
 
@@ -191,8 +179,10 @@ export function createSetupApp(options: SetupAppOptions = {}): Hono {
       return c.json({ error: 'invalid JSON body' }, 400);
     }
     const index = Number(body.index);
-    if (!Number.isInteger(index) || index < 0) {
-      return c.json({ error: 'index must be a non-negative integer' }, 400);
+    // MitID identity indices are 1-based — `0` is treated as "no identity
+    // selected" by the rest of the auth pipeline, so refuse it explicitly.
+    if (!Number.isInteger(index) || index < 1) {
+      return c.json({ error: 'index must be a positive integer' }, 400);
     }
     session.pendingIdentity(index);
     session.pendingIdentity = null;
@@ -236,12 +226,28 @@ async function runLogin(session: LoginSession, store: TokenStore, logger: Logger
         await emit('identity', {
           options: options.map((o) => ({ index: o.index, name: o.name })),
         });
+        // Wait for the user to POST /login/identity, with two escape hatches:
+        // (a) the request abort (browser closes the SSE stream) and
+        // (b) a hard timeout so a user who walks away doesn't leak the
+        //     session entry forever.
         const choice = await new Promise<number>((resolve, reject) => {
-          session.pendingIdentity = resolve;
-          session.abort.signal.addEventListener('abort', () => reject(new Error('aborted')), {
-            once: true,
-          });
+          let settled = false;
+          const settle = (fn: () => void): void => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            session.abort.signal.removeEventListener('abort', onAbort);
+            fn();
+          };
+          session.pendingIdentity = (idx) => settle(() => resolve(idx));
+          const onAbort = (): void => settle(() => reject(new Error('aborted')));
+          session.abort.signal.addEventListener('abort', onAbort, { once: true });
+          const timer = setTimeout(
+            () => settle(() => reject(new Error('identity selection timed out'))),
+            IDENTITY_PICK_TIMEOUT_MS,
+          );
         });
+        session.pendingIdentity = null;
         identityIndex = choice;
         identityName = options.find((o) => o.index === choice)?.name;
         await emit('identity-selected', { index: choice, name: identityName ?? null });
@@ -300,11 +306,20 @@ async function runLogin(session: LoginSession, store: TokenStore, logger: Logger
       name: error.name,
       message: error.message,
     });
+  } finally {
+    // Always signal — the SSE route handler waits on this to clean up the
+    // session entry. Without this, an unexpected throw could leak the entry
+    // until process restart.
+    session.signalDone();
   }
 }
 
 function defaultAddonStore(): TokenStore {
-  const dir = process.env.AULA_MCP_DIR ?? '/config/aula-mcp';
+  // Mirror AulaContext's default store path resolution: honour AULA_MCP_DIR
+  // when set (the HA addon's run.sh exports it to /config/aula-mcp), and
+  // otherwise fall back to ~/.config/aula-mcp so non-addon deployments (dev
+  // boxes, VPS) don't try to write into a non-existent /config directory.
+  const dir = process.env.AULA_MCP_DIR ?? join(homedir(), '.config', 'aula-mcp');
   return new EncryptedFileTokenStore({
     filePath: join(dir, 'tokens.json'),
     keyFilePath: join(dir, '.key'),

--- a/packages/mcp-server/src/setup-ui.ts
+++ b/packages/mcp-server/src/setup-ui.ts
@@ -1,0 +1,561 @@
+/**
+ * In-addon setup / login UI.
+ *
+ * Standalone Hono app served on a second port (default 8099). Home Assistant
+ * proxies it via Ingress, so the user opens "Aula" in HA's sidebar and gets
+ * an interactive MitID login flow without ever leaving HA.
+ *
+ * Flow:
+ *   1. GET  /            → HTML page. Shows token status + "Start login" button.
+ *   2. POST /login/start → kicks off MitID APP-method login. Returns sessionId.
+ *   3. GET  /login/events?sessionId=… → SSE stream:
+ *        event: qr            data: { svg, refreshCount }
+ *        event: otp           data: { code }
+ *        event: verified      data: {}
+ *        event: identity      data: { options: [{ index, name }] }
+ *        event: success       data: { identityName?, expiresInSec }
+ *        event: error         data: { message }
+ *   4. POST /login/identity?sessionId=… { index } → resolves selectIdentity.
+ *
+ * The same `AulaLoginClient` the CLI uses runs in the addon — no duplication
+ * of MitID logic. We just translate its callbacks into SSE events.
+ *
+ * Routes are stateful per login session: `loginSessions` holds the SSE
+ * writer, the in-flight selectIdentity resolver, and the abort signal. A
+ * single user (single household) is the design point; concurrent logins
+ * aren't useful and aren't supported.
+ */
+
+import { join } from 'node:path';
+import {
+  AulaHttpClient,
+  AulaLoginClient,
+  EncryptedFileTokenStore,
+  type IdentityOption,
+  type Logger,
+  type StoredTokenRecord,
+  silentLogger,
+  type TokenStore,
+} from '@aula-mcp/aula-auth';
+import { Hono } from 'hono';
+import { type SSEStreamingApi, streamSSE } from 'hono/streaming';
+import QRCode from 'qrcode';
+
+export interface SetupAppOptions {
+  logger?: Logger;
+  /** Override the token store (tests). Production uses the addon's
+   *  EncryptedFileTokenStore under `AULA_MCP_DIR`. */
+  store?: TokenStore;
+}
+
+interface LoginSession {
+  sessionId: string;
+  username: string;
+  stream?: SSEStreamingApi;
+  /** Resolves when the SSE stream is attached, so events posted before the
+   *  browser GETs /login/events get buffered + delivered. */
+  streamReady: Promise<SSEStreamingApi>;
+  resolveStream: (s: SSEStreamingApi) => void;
+  /** Resolver waiting on user identity choice; null when no pending pick. */
+  pendingIdentity: ((index: number) => void) | null;
+  /** Queue of events that arrived before the stream was attached. */
+  bufferedEvents: Array<{ event: string; data: string }>;
+  abort: AbortController;
+  /** Set when the login resolves (success or error) so /login/events can
+   *  emit the terminal event and close cleanly. */
+  terminal?: { event: 'success' | 'error'; data: string };
+}
+
+const ICON_SVG = `<svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path d="M12 3 1 9l11 6 9-4.91V17h2V9z"/></svg>`;
+
+export function createSetupApp(options: SetupAppOptions = {}): Hono {
+  const logger = options.logger ?? silentLogger;
+  const store = options.store ?? defaultAddonStore();
+  const loginSessions = new Map<string, LoginSession>();
+
+  const app = new Hono();
+
+  app.get('/', (c) => c.html(renderSetupPage()));
+
+  app.get('/status', async (c) => {
+    const record = await store.load();
+    if (!record) return c.json({ logged_in: false });
+    const now = Math.floor(Date.now() / 1000);
+    return c.json({
+      logged_in: true,
+      username: record.username,
+      identity_name: record.identityName ?? null,
+      expires_at: record.tokens.expires_at,
+      seconds_remaining: Math.max(0, record.tokens.expires_at - now),
+      saved_at: record.saved_at,
+    });
+  });
+
+  app.post('/login/start', async (c) => {
+    let body: { username?: string };
+    try {
+      body = (await c.req.json()) as { username?: string };
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    const username = (body.username ?? '').trim();
+    if (!username) return c.json({ error: 'username is required' }, 400);
+
+    const sessionId = crypto.randomUUID();
+    let resolveStream!: (s: SSEStreamingApi) => void;
+    const streamReady = new Promise<SSEStreamingApi>((resolve) => {
+      resolveStream = resolve;
+    });
+    const session: LoginSession = {
+      sessionId,
+      username,
+      streamReady,
+      resolveStream,
+      pendingIdentity: null,
+      bufferedEvents: [],
+      abort: new AbortController(),
+    };
+    loginSessions.set(sessionId, session);
+
+    // Fire the login in the background; the route returns the sessionId
+    // immediately so the browser can subscribe to /login/events.
+    runLogin(session, store, logger).catch((err) => {
+      logger.error('setup.login.unexpected_error', { error: (err as Error).message });
+    });
+
+    return c.json({ sessionId });
+  });
+
+  app.get('/login/events', (c) => {
+    const sessionId = c.req.query('sessionId');
+    if (!sessionId) return c.json({ error: 'missing sessionId' }, 400);
+    const session = loginSessions.get(sessionId);
+    if (!session) return c.json({ error: 'unknown sessionId' }, 404);
+
+    return streamSSE(c, async (stream) => {
+      session.stream = stream;
+      session.resolveStream(stream);
+
+      // Drain any events buffered before the stream attached.
+      for (const ev of session.bufferedEvents) {
+        await stream.writeSSE(ev);
+      }
+      session.bufferedEvents.length = 0;
+
+      // Replay terminal event if login already finished before the browser
+      // got here (shouldn't happen in practice — login takes seconds — but
+      // belt and suspenders).
+      if (session.terminal) {
+        await stream.writeSSE(session.terminal);
+        loginSessions.delete(sessionId);
+        return;
+      }
+
+      // Hold the stream open until the login finishes. The login emits
+      // events via session.stream.writeSSE directly; this promise resolves
+      // when the terminal event is sent.
+      await new Promise<void>((resolve) => {
+        stream.onAbort(() => {
+          session.abort.abort();
+          loginSessions.delete(sessionId);
+          resolve();
+        });
+        // resolveOnTerminal hook installed by runLogin via session.terminal
+        const interval = setInterval(() => {
+          if (session.terminal) {
+            clearInterval(interval);
+            // Replay terminal in case it landed after the buffer drain.
+            session.stream
+              ?.writeSSE(session.terminal)
+              .catch(() => {})
+              .finally(() => {
+                loginSessions.delete(sessionId);
+                resolve();
+              });
+          }
+        }, 250);
+      });
+    });
+  });
+
+  app.post('/login/identity', async (c) => {
+    const sessionId = c.req.query('sessionId');
+    if (!sessionId) return c.json({ error: 'missing sessionId' }, 400);
+    const session = loginSessions.get(sessionId);
+    if (!session) return c.json({ error: 'unknown sessionId' }, 404);
+    if (!session.pendingIdentity) return c.json({ error: 'no pending identity choice' }, 409);
+    let body: { index?: number };
+    try {
+      body = (await c.req.json()) as { index?: number };
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    const index = Number(body.index);
+    if (!Number.isInteger(index) || index < 0) {
+      return c.json({ error: 'index must be a non-negative integer' }, 400);
+    }
+    session.pendingIdentity(index);
+    session.pendingIdentity = null;
+    return c.body(null, 202);
+  });
+
+  app.post('/logout', async (c) => {
+    await store.clear();
+    return c.json({ ok: true });
+  });
+
+  return app;
+}
+
+async function runLogin(session: LoginSession, store: TokenStore, logger: Logger): Promise<void> {
+  const http = new AulaHttpClient({ logger });
+  const client = new AulaLoginClient({ http, logger });
+  let lastQrCount = -1;
+  let identityName: string | undefined;
+  let identityIndex: number | undefined;
+
+  const emit = async (event: string, data: unknown): Promise<void> => {
+    const payload = { event, data: JSON.stringify(data) };
+    if (session.stream && !session.stream.aborted) {
+      try {
+        await session.stream.writeSSE(payload);
+        return;
+      } catch (err) {
+        logger.error('setup.login.sse_write_error', { error: (err as Error).message });
+      }
+    }
+    session.bufferedEvents.push(payload);
+  };
+
+  try {
+    const tokens = await client.login({
+      username: session.username,
+      method: 'APP',
+      signal: session.abort.signal,
+      selectIdentity: async (options: IdentityOption[]) => {
+        await emit('identity', {
+          options: options.map((o) => ({ index: o.index, name: o.name })),
+        });
+        const choice = await new Promise<number>((resolve, reject) => {
+          session.pendingIdentity = resolve;
+          session.abort.signal.addEventListener('abort', () => reject(new Error('aborted')), {
+            once: true,
+          });
+        });
+        identityIndex = choice;
+        identityName = options.find((o) => o.index === choice)?.name;
+        await emit('identity-selected', { index: choice, name: identityName ?? null });
+        return choice;
+      },
+      appCallbacks: {
+        onOtp: async (otp) => {
+          await emit('otp', { code: otp });
+        },
+        onQr: async ({ qr1Json, qr2Json, updateCount }) => {
+          if (updateCount === lastQrCount) return;
+          lastQrCount = updateCount;
+          const [svg1, svg2] = await Promise.all([
+            QRCode.toString(qr1Json, { type: 'svg', errorCorrectionLevel: 'M', margin: 1 }),
+            QRCode.toString(qr2Json, { type: 'svg', errorCorrectionLevel: 'M', margin: 1 }),
+          ]);
+          await emit('qr', { svg1, svg2, refreshCount: updateCount });
+        },
+        onVerified: async () => {
+          await emit('verified', {});
+        },
+      },
+    });
+
+    const now = Math.floor(Date.now() / 1000);
+    const record: StoredTokenRecord = {
+      version: 1,
+      username: session.username,
+      tokens,
+      saved_at: now,
+      ...(identityIndex !== undefined ? { identityIndex } : {}),
+      ...(identityName ? { identityName } : {}),
+    };
+    await store.save(record);
+
+    const terminal = {
+      event: 'success' as const,
+      data: JSON.stringify({
+        identityName: identityName ?? null,
+        expiresInSec: Math.max(0, tokens.expires_at - now),
+      }),
+    };
+    session.terminal = terminal;
+    await emit('success', JSON.parse(terminal.data));
+    logger.info('setup.login.success', { username: session.username });
+  } catch (err) {
+    const error = err as Error;
+    const terminal = {
+      event: 'error' as const,
+      data: JSON.stringify({ message: error.message, name: error.name ?? 'Error' }),
+    };
+    session.terminal = terminal;
+    await emit('error', JSON.parse(terminal.data));
+    logger.error('setup.login.failed', {
+      username: session.username,
+      name: error.name,
+      message: error.message,
+    });
+  }
+}
+
+function defaultAddonStore(): TokenStore {
+  const dir = process.env.AULA_MCP_DIR ?? '/config/aula-mcp';
+  return new EncryptedFileTokenStore({
+    filePath: join(dir, 'tokens.json'),
+    keyFilePath: join(dir, '.key'),
+  });
+}
+
+function renderSetupPage(): string {
+  // Inline single-page UI. Vanilla JS + EventSource so it works without a
+  // build step inside the addon. Styling kept minimal to match HA's frame.
+  return `<!doctype html>
+<html lang="da">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>aula-mcp — login</title>
+<style>
+  :root { color-scheme: light dark; --fg: #1d1d1f; --muted: #6b7280; --bg: #ffffff; --card: #f7f7f8; --border: #e5e7eb; --accent: #03a9f4; --error: #b00020; --success: #117a3a; }
+  @media (prefers-color-scheme: dark) { :root { --fg: #f5f5f7; --muted: #a1a1aa; --bg: #111114; --card: #1c1c1f; --border: #2a2a2e; } }
+  * { box-sizing: border-box; }
+  body { font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: var(--fg); background: var(--bg); margin: 0; padding: 2rem 1rem; }
+  main { max-width: 640px; margin: 0 auto; }
+  h1 { font-size: 1.4rem; margin: 0 0 0.5rem; display: flex; align-items: center; gap: 0.5rem; }
+  h1 svg { color: var(--accent); }
+  p { color: var(--muted); margin: 0 0 1rem; }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 1.25rem; margin: 1rem 0; }
+  .qr-wrap { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1rem 0; }
+  .qr-wrap > div { background: #fff; border-radius: 8px; padding: 0.5rem; display: flex; align-items: center; justify-content: center; }
+  .qr-wrap svg { width: 100%; height: auto; max-width: 240px; }
+  label { display: block; font-weight: 500; margin-bottom: 0.25rem; }
+  input[type=text] { width: 100%; padding: 0.6rem 0.75rem; font-size: 1rem; border: 1px solid var(--border); border-radius: 8px; background: var(--bg); color: var(--fg); }
+  button { font: inherit; padding: 0.6rem 1.1rem; border-radius: 8px; border: 0; background: var(--accent); color: #fff; font-weight: 500; cursor: pointer; }
+  button:disabled { opacity: 0.6; cursor: not-allowed; }
+  button.secondary { background: transparent; color: var(--fg); border: 1px solid var(--border); }
+  .row { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+  .status-line { display: flex; align-items: center; gap: 0.5rem; font-size: 0.95rem; }
+  .dot { width: 0.6rem; height: 0.6rem; border-radius: 50%; background: var(--muted); }
+  .dot.ok { background: var(--success); }
+  .dot.err { background: var(--error); }
+  .stage { font-weight: 500; }
+  .stage.error { color: var(--error); }
+  .stage.success { color: var(--success); }
+  .identity-options button { margin: 0.25rem 0.5rem 0.25rem 0; background: var(--card); color: var(--fg); border: 1px solid var(--border); }
+  .muted { color: var(--muted); font-size: 0.85rem; }
+  details { margin-top: 1rem; }
+  summary { cursor: pointer; color: var(--muted); }
+  code { background: var(--card); border: 1px solid var(--border); padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.9em; }
+</style>
+</head>
+<body>
+<main>
+  <h1>${ICON_SVG} aula-mcp</h1>
+  <p>Log ind med MitID, så HA's Assist + Voice kan tale med Aula.</p>
+
+  <div class="card" id="status-card">
+    <div class="status-line">
+      <span class="dot" id="status-dot"></span>
+      <span id="status-text">Indlæser status…</span>
+    </div>
+    <div id="status-detail" class="muted" style="margin-top: 0.5rem;"></div>
+    <div class="row" id="status-actions" style="margin-top: 0.75rem;"></div>
+  </div>
+
+  <div class="card" id="login-card" hidden>
+    <label for="username">MitID-brugernavn</label>
+    <input type="text" id="username" placeholder="dit MitID-username" autocomplete="username" />
+    <div class="row" style="margin-top: 0.75rem;">
+      <button id="start-btn">Start login</button>
+      <span class="muted">Du scanner QR-koden med MitID-appen.</span>
+    </div>
+  </div>
+
+  <div class="card" id="progress-card" hidden>
+    <div class="status-line">
+      <span class="dot" id="progress-dot"></span>
+      <span class="stage" id="stage">Starter…</span>
+    </div>
+    <div id="progress-detail" class="muted" style="margin-top: 0.5rem;"></div>
+    <div class="qr-wrap" id="qr-wrap" hidden></div>
+    <div id="identity-choice" hidden style="margin-top: 1rem;">
+      <p style="margin: 0 0 0.5rem;">Du har flere identiteter — vælg den der hører til Aula:</p>
+      <div class="identity-options" id="identity-options"></div>
+    </div>
+  </div>
+
+  <details>
+    <summary>Hvad sker der her?</summary>
+    <p class="muted">Login-flow'et kører lokalt i din HA-installation. MitID-godkendelsen sker mellem MitID-appen og <code>nemlog-in.mitid.dk</code> — denne side ser kun de OAuth-tokens du får tilbage, og gemmer dem krypteret i <code>/config/aula-mcp/</code>. Tokens forlader ikke din HA.</p>
+  </details>
+</main>
+
+<script>
+const $ = (id) => document.getElementById(id);
+const statusDot = $('status-dot');
+const statusText = $('status-text');
+const statusDetail = $('status-detail');
+const statusActions = $('status-actions');
+const loginCard = $('login-card');
+const progressCard = $('progress-card');
+const progressDot = $('progress-dot');
+const stage = $('stage');
+const progressDetail = $('progress-detail');
+const qrWrap = $('qr-wrap');
+const identityChoice = $('identity-choice');
+const identityOptions = $('identity-options');
+const startBtn = $('start-btn');
+const usernameInput = $('username');
+
+let currentSessionId = null;
+let currentSource = null;
+
+async function refreshStatus() {
+  const res = await fetch('status');
+  const data = await res.json();
+  if (data.logged_in) {
+    statusDot.classList.add('ok');
+    statusDot.classList.remove('err');
+    statusText.textContent = 'Logget ind';
+    const expiresMin = Math.round(data.seconds_remaining / 60);
+    statusDetail.textContent = (data.identity_name ? data.identity_name + ' — ' : '') +
+      (data.username) + '. Access token udløber om ' + expiresMin + ' min.';
+    statusActions.innerHTML = '';
+    const logoutBtn = document.createElement('button');
+    logoutBtn.textContent = 'Log ud';
+    logoutBtn.className = 'secondary';
+    logoutBtn.onclick = async () => {
+      await fetch('logout', { method: 'POST' });
+      await refreshStatus();
+    };
+    statusActions.appendChild(logoutBtn);
+    loginCard.hidden = true;
+  } else {
+    statusDot.classList.remove('ok', 'err');
+    statusText.textContent = 'Ikke logget ind';
+    statusDetail.textContent = 'Klik nedenfor for at starte MitID-login.';
+    statusActions.innerHTML = '';
+    loginCard.hidden = false;
+  }
+}
+
+function setStage(text, kind = '') {
+  stage.textContent = text;
+  stage.classList.remove('error', 'success');
+  if (kind) stage.classList.add(kind);
+  progressDot.classList.remove('ok', 'err');
+  if (kind === 'success') progressDot.classList.add('ok');
+  if (kind === 'error') progressDot.classList.add('err');
+}
+
+function showQR(svg1, svg2, refresh) {
+  qrWrap.hidden = false;
+  qrWrap.innerHTML = '<div>' + svg1 + '</div><div>' + svg2 + '</div>';
+  progressDetail.textContent = 'Scan en af QR-koderne med MitID-appen (skifter automatisk).';
+}
+
+function showIdentityChoice(options) {
+  identityChoice.hidden = false;
+  identityOptions.innerHTML = '';
+  for (const opt of options) {
+    const btn = document.createElement('button');
+    btn.textContent = opt.name;
+    btn.onclick = async () => {
+      identityOptions.innerHTML = '<span class="muted">Vælger ' + opt.name + '…</span>';
+      await fetch('login/identity?sessionId=' + encodeURIComponent(currentSessionId), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ index: opt.index }),
+      });
+    };
+    identityOptions.appendChild(btn);
+  }
+}
+
+startBtn.onclick = async () => {
+  const username = usernameInput.value.trim();
+  if (!username) {
+    usernameInput.focus();
+    return;
+  }
+  startBtn.disabled = true;
+  loginCard.hidden = true;
+  progressCard.hidden = false;
+  qrWrap.hidden = true;
+  identityChoice.hidden = true;
+  setStage('Starter login…');
+  progressDetail.textContent = '';
+
+  const res = await fetch('login/start', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username }),
+  });
+  if (!res.ok) {
+    setStage('Kunne ikke starte login', 'error');
+    progressDetail.textContent = 'HTTP ' + res.status + ' — tjek log.';
+    startBtn.disabled = false;
+    return;
+  }
+  const { sessionId } = await res.json();
+  currentSessionId = sessionId;
+
+  currentSource = new EventSource('login/events?sessionId=' + encodeURIComponent(sessionId));
+
+  currentSource.addEventListener('qr', (ev) => {
+    setStage('Venter på MitID');
+    const data = JSON.parse(ev.data);
+    showQR(data.svg1, data.svg2, data.refreshCount);
+  });
+  currentSource.addEventListener('otp', (ev) => {
+    const data = JSON.parse(ev.data);
+    setStage('Indtast OTP i MitID-appen');
+    progressDetail.textContent = 'Kode: ' + data.code;
+  });
+  currentSource.addEventListener('verified', () => {
+    setStage('Bekræft i MitID-appen');
+    progressDetail.textContent = 'Godkend login i MitID-appen.';
+  });
+  currentSource.addEventListener('identity', (ev) => {
+    setStage('Vælg identitet');
+    const data = JSON.parse(ev.data);
+    showIdentityChoice(data.options);
+  });
+  currentSource.addEventListener('identity-selected', () => {
+    identityChoice.hidden = true;
+    setStage('Fortsætter…');
+  });
+  currentSource.addEventListener('success', async (ev) => {
+    setStage('Logget ind 🎉', 'success');
+    const data = JSON.parse(ev.data);
+    progressDetail.textContent = 'Tokens gemt. ' +
+      (data.identityName ? 'Identitet: ' + data.identityName + '. ' : '') +
+      'Access udløber om ' + Math.round((data.expiresInSec || 0) / 60) + ' min.';
+    currentSource.close();
+    startBtn.disabled = false;
+    await refreshStatus();
+  });
+  currentSource.addEventListener('error', (ev) => {
+    if (!ev.data) return;
+    setStage('Login fejlede', 'error');
+    try {
+      const data = JSON.parse(ev.data);
+      progressDetail.textContent = data.message || 'Ukendt fejl.';
+    } catch {
+      progressDetail.textContent = 'Forbindelsen blev afbrudt.';
+    }
+    currentSource.close();
+    startBtn.disabled = false;
+  });
+};
+
+refreshStatus();
+</script>
+</body>
+</html>`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,16 @@ importers:
       hono:
         specifier: ^4.12.18
         version: 4.12.18
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       zod:
         specifier: ^4.4.3
         version: 4.4.3
+    devDependencies:
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
 
 packages:
 
@@ -147,6 +154,9 @@ packages:
   '@types/qrcode-terminal@0.12.2':
     resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -161,6 +171,14 @@ packages:
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -184,12 +202,26 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
 
   cheerio@1.2.0:
     resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
     engines: {node: '>=20.18.1'}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -231,9 +263,16 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -254,6 +293,9 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -321,6 +363,10 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -331,6 +377,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -382,6 +432,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -396,6 +450,10 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -442,6 +500,18 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
 
@@ -455,6 +525,10 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -466,12 +540,21 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
   qrcode-terminal@0.12.0:
     resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
+    hasBin: true
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
     hasBin: true
 
   qs@6.15.1:
@@ -486,9 +569,16 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -504,6 +594,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -535,6 +628,14 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   tldts-core@7.0.30:
     resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
@@ -584,13 +685,31 @@ packages:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -673,6 +792,10 @@ snapshots:
 
   '@types/qrcode-terminal@0.12.2': {}
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 25.6.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -688,6 +811,12 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   body-parser@2.2.2:
     dependencies:
@@ -721,6 +850,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  camelcase@5.3.1: {}
+
   cheerio-select@2.1.0:
     dependencies:
       boolbase: 1.0.0
@@ -743,6 +874,18 @@ snapshots:
       parse5-parser-stream: 7.1.2
       undici: 7.25.0
       whatwg-mimetype: 4.0.0
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   content-disposition@1.1.0: {}
 
@@ -777,7 +920,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   depd@2.0.0: {}
+
+  dijkstrajs@1.0.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -804,6 +951,8 @@ snapshots:
       gopd: 1.2.0
 
   ee-first@1.1.1: {}
+
+  emoji-regex@8.0.0: {}
 
   encodeurl@2.0.0: {}
 
@@ -889,11 +1038,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
 
   function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -952,6 +1108,8 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
@@ -961,6 +1119,10 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
 
   math-intrinsics@1.1.0: {}
 
@@ -994,6 +1156,16 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
@@ -1009,11 +1181,15 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-exists@4.0.0: {}
+
   path-key@3.1.1: {}
 
   path-to-regexp@8.4.2: {}
 
   pkce-challenge@5.0.1: {}
+
+  pngjs@5.0.0: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -1021,6 +1197,12 @@ snapshots:
       ipaddr.js: 1.9.1
 
   qrcode-terminal@0.12.0: {}
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   qs@6.15.1:
     dependencies:
@@ -1035,7 +1217,11 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
+
+  require-main-filename@2.0.0: {}
 
   router@2.2.0:
     dependencies:
@@ -1073,6 +1259,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-blocking@2.0.0: {}
 
   setprototypeof@1.2.0: {}
 
@@ -1112,6 +1300,16 @@ snapshots:
 
   statuses@2.0.2: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   tldts-core@7.0.30: {}
 
   tldts@7.0.30:
@@ -1146,11 +1344,40 @@ snapshots:
 
   whatwg-mimetype@4.0.0: {}
 
+  which-module@2.0.1: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
+
+  y18n@4.0.3: {}
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
## Summary

Replaces the "log in on a workstation, scp the bundle to /config/aula-mcp" first-time flow with a **one-click login UI in HA's sidebar**, mounted via Ingress. The workstation-export path still works as a fallback.

Built on **PR #19** (the addon scaffolding) — set the PR's base to `feat/ha-addon` so the diff stays focused on this change. The workstation-export flow described in #19's README is replaced by the in-UI flow here.

## What the user sees

1. After installing the addon (one-click via the badge in #19), there's an **aula-mcp** entry in HA's sidebar.
2. Page opens to *"Ikke logget ind"*. User types MitID username, clicks Start.
3. Two MitID QR codes appear (alternating, anti-phishing). User scans with the MitID app.
4. *"Bekræft i MitID-appen"* → user approves on phone.
5. If multiple identities: pick the right one inline.
6. *"Logget ind 🎉"* — tokens encrypted to `/config/aula-mcp/`, MCP server picks them up.

Everything happens behind HA's Ingress proxy. The browser stays in the HA UI; MitID-app talks to nemlog-in.dk directly. The addon only sees the OAuth tokens.

## Architecture

- `homeassistant-addon/config.yaml`: adds `ingress: true`, `ingress_port: 8099`, `panel_icon: mdi:school`, `panel_title: aula-mcp`.
- `homeassistant-addon/run.sh`: exports `AULA_MCP_INGRESS_PORT=8099`.
- `packages/mcp-server/src/setup-ui.ts` (new, ~560 lines): standalone Hono app with the login UI + JSON-RPC-style endpoints. Routes documented in the file header. Embedded HTML page (vanilla JS + EventSource — no build step inside the addon).
- `packages/mcp-server/src/server.ts`: boots a second \`Bun.serve\` for the setup app when `AULA_MCP_INGRESS_PORT` is set. Unset in non-addon deployments (CLI workstation, VPS) so they don't open the port.
- Login logic is **not duplicated** — `AulaLoginClient` from `@aula-mcp/aula-auth` is the same one `pnpm login` uses. The setup app translates `AppAuthCallbacks` (onQr/onOtp/onVerified) + `selectIdentity` into SSE events.

## Endpoints (new, on port 8099)

| Route | Purpose |
| --- | --- |
| `GET /` | Login HTML (Danish-first). Vanilla JS + EventSource. |
| `GET /status` | Current token state — logged_in, username, identity_name, seconds_remaining. |
| `POST /login/start` | Kick off MitID APP login. Returns `{sessionId}`. |
| `GET /login/events?sessionId=…` | SSE stream: `qr`, `otp`, `verified`, `identity`, `identity-selected`, `success`, `error`. |
| `POST /login/identity?sessionId=…` | Pick identity (multi-identity parents). |
| `POST /logout` | Clear the token store. |

## Trade-offs / deferred

- **APP method only.** CODE_TOKEN + PASSWORD remain CLI-only. Most parents use the MitID app QR flow anyway.
- **Single concurrent login session.** Two simultaneous logins would race on the token store; refused by design.
- **Danish-first copy.** Matches the rest of the project; i18n can come when there's demand.
- **No integration test for the actual MitID flow** — that needs network mocks of Aula/MitID's full chain (out of scope; `AulaLoginClient` is exercised by the auth package's own tests).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `bun test packages/mcp-server` — 37 pass (28 existing + 9 new route-shape tests)
- [x] `pnpm exec biome check packages/mcp-server/src/setup-ui.ts` — clean (after autofix for import order)
- [ ] **End-to-end on real HA hardware** — install via #19's badge, open the sidebar panel, complete a MitID login, verify the addon's MCP server then has working tokens. Needs your hardware.

## Merge order

#18 (SSE transport) and #19 (addon scaffolding) first. Then this — it stacks on #19's branch.