### PR TITLE
fix(mcp-server): cap + idle-evict SSE sessions, validate inbound JSON-RPC

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -25,11 +25,14 @@
  *   AULA_MCP_ALLOW_REMOTE=1   — allow binding to non-loopback addresses (refuses
  *                               by default; the server is single-user and any
  *                               peer with /mcp access can drive your tokens)
+ *   AULA_MCP_SSE_MAX_SESSIONS — max concurrent legacy /sse sessions before new
+ *                               GET /sse requests get 503'd (default 16)
+ *   AULA_MCP_SSE_IDLE_MS      — evict /sse sessions idle for >this many ms
+ *                               (default 300_000 = 5 min)
  */
 
 import { consoleLogger, silentLogger } from '@aula-mcp/aula-auth';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
-import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import { createMcpApp, type McpApp } from './setup.ts';
@@ -71,45 +74,100 @@ app.delete('/mcp', (c) => handleMcp(c.req.raw));
 // GET /sse opens a fresh session: own McpServer instance, own AulaContext,
 // own sessionId. POSTs to /messages?sessionId=… get routed back to the
 // matching session's transport.
+//
+// The session map is capped + idle-evicted. The MCP server defaults to
+// loopback, but the HA addon exposes it on the LAN, so an unbounded map is
+// a footgun — a crashed/looping client could pile up sessions indefinitely.
 interface SseSession {
   transport: HonoSseTransport;
   app: McpApp;
+  lastActivityAt: number;
 }
+const SSE_MAX_SESSIONS = Math.max(1, Number(process.env.AULA_MCP_SSE_MAX_SESSIONS ?? 16));
+const SSE_IDLE_MS = Math.max(1_000, Number(process.env.AULA_MCP_SSE_IDLE_MS ?? 300_000));
+const SSE_SWEEP_INTERVAL_MS = Math.max(1_000, Math.floor(SSE_IDLE_MS / 4));
 const sseSessions = new Map<string, SseSession>();
 
-app.get('/sse', (c) =>
-  streamSSE(c, async (stream) => {
+async function closeSseSession(sessionId: string, reason: string): Promise<void> {
+  const session = sseSessions.get(sessionId);
+  if (!session) return;
+  sseSessions.delete(sessionId);
+  try {
+    await session.transport.close();
+  } catch (err) {
+    logger.error('aula-mcp.sse.transport_close_error', {
+      sessionId,
+      reason,
+      error: (err as Error).message,
+    });
+  }
+  try {
+    await session.app.mcp.close();
+  } catch (err) {
+    logger.error('aula-mcp.sse.mcp_close_error', {
+      sessionId,
+      reason,
+      error: (err as Error).message,
+    });
+  }
+}
+
+// Single sweeper, started once at boot. `unref()` so the interval doesn't
+// keep the process alive on its own — the shutdown handler clears it
+// explicitly anyway, but unref() is belt-and-braces in case of a bug.
+const sseSweeper: ReturnType<typeof setInterval> = setInterval(() => {
+  const now = Date.now();
+  for (const [sessionId, session] of sseSessions) {
+    if (now - session.lastActivityAt > SSE_IDLE_MS) {
+      logger.info('aula-mcp.sse.session_evicted_idle', {
+        sessionId,
+        idleMs: now - session.lastActivityAt,
+      });
+      void closeSseSession(sessionId, 'idle');
+    }
+  }
+}, SSE_SWEEP_INTERVAL_MS);
+sseSweeper.unref?.();
+
+app.get('/sse', (c) => {
+  if (sseSessions.size >= SSE_MAX_SESSIONS) {
+    logger.error('aula-mcp.sse.session_rejected_cap', {
+      active: sseSessions.size,
+      cap: SSE_MAX_SESSIONS,
+    });
+    return c.json(
+      {
+        error: 'sse session cap reached',
+        active: sseSessions.size,
+        cap: SSE_MAX_SESSIONS,
+      },
+      503,
+    );
+  }
+  return streamSSE(c, async (stream) => {
     const sessionId = crypto.randomUUID();
     const sseTransport = new HonoSseTransport({
       sessionId,
       messageEndpoint: '/messages',
       stream,
+      onActivity: () => {
+        const s = sseSessions.get(sessionId);
+        if (s) s.lastActivityAt = Date.now();
+      },
     });
     // McpServer.connect() binds a single transport, so we instantiate a
     // fresh server per SSE connection. AulaContext is cheap to construct
     // — it just lazily wraps the shared token store on first call.
     const sessionApp = createMcpApp({ logger });
-    sseSessions.set(sessionId, { transport: sseTransport, app: sessionApp });
+    sseSessions.set(sessionId, {
+      transport: sseTransport,
+      app: sessionApp,
+      lastActivityAt: Date.now(),
+    });
 
     const closed = new Promise<void>((resolve) => {
       stream.onAbort(async () => {
-        sseSessions.delete(sessionId);
-        try {
-          await sseTransport.close();
-        } catch (err) {
-          logger.error('aula-mcp.sse.transport_close_error', {
-            sessionId,
-            error: (err as Error).message,
-          });
-        }
-        try {
-          await sessionApp.mcp.close();
-        } catch (err) {
-          logger.error('aula-mcp.sse.mcp_close_error', {
-            sessionId,
-            error: (err as Error).message,
-          });
-        }
+        await closeSseSession(sessionId, 'abort');
         resolve();
       });
     });
@@ -124,27 +182,28 @@ app.get('/sse', (c) =>
         sessionId,
         error: (err as Error).message,
       });
-      sseSessions.delete(sessionId);
+      await closeSseSession(sessionId, 'connect_failed');
       return;
     }
 
     // Hold the SSE stream open until the client disconnects.
     await closed;
     logger.info('aula-mcp.sse.session_closed', { sessionId });
-  }),
-);
+  });
+});
 
 app.post('/messages', async (c) => {
   const sessionId = c.req.query('sessionId');
   if (!sessionId) return c.json({ error: 'missing sessionId query parameter' }, 400);
   const session = sseSessions.get(sessionId);
   if (!session) return c.json({ error: 'unknown sessionId' }, 404);
-  let body: JSONRPCMessage;
+  let body: unknown;
   try {
-    body = (await c.req.json()) as JSONRPCMessage;
+    body = await c.req.json();
   } catch {
     return c.json({ error: 'invalid JSON body' }, 400);
   }
+  session.lastActivityAt = Date.now();
   session.transport.receive(body);
   // The actual JSON-RPC response is delivered over the SSE channel; the POST
   // is just an inbound carrier, so 202 Accepted is the spec-correct ack.
@@ -171,7 +230,14 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   if (shuttingDown) return;
   shuttingDown = true;
   process.stdout.write(`\n${signal} received — shutting down gracefully…\n`);
+  // Stop the idle sweeper first so it can't fire mid-shutdown and race with
+  // session cleanup; this also lets the event loop drain if anything still
+  // refs the interval.
+  clearInterval(sseSweeper);
   try {
+    await Promise.all(
+      Array.from(sseSessions.keys()).map((sid) => closeSseSession(sid, 'shutdown')),
+    );
     await server.stop();
     await mcp.close();
   } catch (err) {

--- a/packages/mcp-server/src/sse-transport.test.ts
+++ b/packages/mcp-server/src/sse-transport.test.ts
@@ -18,6 +18,15 @@ import { HonoSseTransport } from './sse-transport.ts';
 interface SseSession {
   transport: HonoSseTransport;
   mcp: McpServer;
+  errors: Error[];
+}
+
+interface TestApp {
+  app: Hono;
+  /** Live session map mirroring the wiring in server.ts. Tests use this to
+   *  inspect the transport state directly (e.g. simulate a torn-down stream
+   *  whose map entry hasn't been swept yet). */
+  sessions: Map<string, SseSession>;
 }
 
 /**
@@ -25,18 +34,22 @@ interface SseSession {
  * the wiring in `server.ts` but with a single in-memory tool so we never
  * touch Aula/AulaContext.
  */
-function buildTestApp(): Hono {
+function buildTestApp(): TestApp {
   const sessions = new Map<string, SseSession>();
   const app = new Hono();
 
   app.get('/sse', (c) =>
     streamSSE(c, async (stream) => {
       const sessionId = crypto.randomUUID();
+      const errors: Error[] = [];
       const transport = new HonoSseTransport({
         sessionId,
         messageEndpoint: '/messages',
         stream,
       });
+      transport.onerror = (err) => {
+        errors.push(err);
+      };
       const mcp = new McpServer(
         { name: 'aula-mcp-test', version: '0.0.0' },
         { capabilities: { tools: {} } },
@@ -50,7 +63,7 @@ function buildTestApp(): Hono {
         },
         async ({ msg }) => ({ content: [{ type: 'text', text: msg }] }),
       );
-      sessions.set(sessionId, { transport, mcp });
+      sessions.set(sessionId, { transport, mcp, errors });
 
       const closed = new Promise<void>((resolve) => {
         stream.onAbort(async () => {
@@ -75,12 +88,12 @@ function buildTestApp(): Hono {
     if (!sessionId) return c.json({ error: 'missing sessionId' }, 400);
     const session = sessions.get(sessionId);
     if (!session) return c.json({ error: 'unknown sessionId' }, 404);
-    const body = (await c.req.json()) as JSONRPCMessage;
+    const body = (await c.req.json()) as unknown;
     session.transport.receive(body);
     return c.body(null, 202);
   });
 
-  return app;
+  return { app, sessions };
 }
 
 interface SseEvent {
@@ -194,7 +207,7 @@ async function sendMessage(
 
 describe('HonoSseTransport', () => {
   test('opens SSE, announces endpoint, completes initialize handshake', async () => {
-    const app = buildTestApp();
+    const { app } = buildTestApp();
     const { reader, sessionId } = await openSse(app);
 
     const initReq: JSONRPCMessage = {
@@ -223,7 +236,7 @@ describe('HonoSseTransport', () => {
   });
 
   test('tools/list returns the echo tool after initialize', async () => {
-    const app = buildTestApp();
+    const { app } = buildTestApp();
     const { reader, sessionId } = await openSse(app);
 
     await sendMessage(app, sessionId, {
@@ -264,7 +277,7 @@ describe('HonoSseTransport', () => {
   });
 
   test('tools/call round-trips through SSE', async () => {
-    const app = buildTestApp();
+    const { app } = buildTestApp();
     const { reader, sessionId } = await openSse(app);
 
     await sendMessage(app, sessionId, {
@@ -303,7 +316,7 @@ describe('HonoSseTransport', () => {
   });
 
   test('POST to /messages with unknown sessionId returns 404', async () => {
-    const app = buildTestApp();
+    const { app } = buildTestApp();
     const res = await sendMessage(app, '00000000-0000-0000-0000-000000000000', {
       jsonrpc: '2.0',
       id: 1,
@@ -314,7 +327,7 @@ describe('HonoSseTransport', () => {
   });
 
   test('POST to /messages without sessionId returns 400', async () => {
-    const app = buildTestApp();
+    const { app } = buildTestApp();
     const res = await app.fetch(
       new Request('http://test/messages', {
         method: 'POST',
@@ -326,7 +339,7 @@ describe('HonoSseTransport', () => {
   });
 
   test('concurrent SSE sessions get distinct ids and isolated tool calls', async () => {
-    const app = buildTestApp();
+    const { app } = buildTestApp();
     const a = await openSse(app);
     const b = await openSse(app);
     expect(a.sessionId).not.toBe(b.sessionId);
@@ -373,5 +386,80 @@ describe('HonoSseTransport', () => {
 
     await a.reader.close();
     await b.reader.close();
+  });
+
+  test('POST to /messages after stream torn down but entry still present is a no-op (onerror, no onmessage)', async () => {
+    // Pins the behaviour at the race between `stream.onAbort` clearing the
+    // session map and a late POST landing on /messages. The route resolves
+    // the entry, calls `transport.receive()`, and the transport short-circuits
+    // because `this.closed === true` — surfacing the late delivery as an
+    // `onerror` event rather than forwarding it to the McpServer (which has
+    // already been torn down).
+    const { app, sessions } = buildTestApp();
+    const { reader, sessionId } = await openSse(app);
+    const session = sessions.get(sessionId);
+    if (!session) throw new Error('session missing immediately after open');
+
+    // Replace onmessage with a spy so we can prove it is NOT invoked.
+    let onmessageCalls = 0;
+    const realOnmessage = session.transport.onmessage;
+    session.transport.onmessage = (msg, extra) => {
+      onmessageCalls += 1;
+      realOnmessage?.(msg, extra);
+    };
+
+    // Tear down the transport WITHOUT removing it from the session map,
+    // simulating the window between `stream.aborted` flipping true and
+    // the abort handler reaching its `sessions.delete()` call.
+    await session.transport.close();
+    expect(sessions.has(sessionId)).toBe(true);
+
+    const errorsBefore = session.errors.length;
+    const res = await sendMessage(app, sessionId, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+    } as JSONRPCMessage);
+    // The route handler treats a known sessionId as 202 Accepted regardless
+    // of the transport's internal state — the actual outcome is reflected
+    // only in the transport's onerror channel.
+    expect(res.status).toBe(202);
+    expect(onmessageCalls).toBe(0);
+    expect(session.errors.length).toBeGreaterThan(errorsBefore);
+    expect(session.errors[session.errors.length - 1]?.message).toMatch(/closed/i);
+
+    await reader.close();
+  });
+
+  test('POST to /messages with malformed JSON-RPC surfaces onerror, not onmessage', async () => {
+    // The transport mirrors the stock SSEServerTransport: inbound payloads
+    // are validated against JSONRPCMessageSchema before being passed to
+    // onmessage. A body missing the `jsonrpc` field must round-trip as an
+    // onerror event so the McpServer never sees a half-typed value.
+    const { app, sessions } = buildTestApp();
+    const { reader, sessionId } = await openSse(app);
+    const session = sessions.get(sessionId);
+    if (!session) throw new Error('session missing immediately after open');
+
+    let onmessageCalls = 0;
+    const realOnmessage = session.transport.onmessage;
+    session.transport.onmessage = (msg, extra) => {
+      onmessageCalls += 1;
+      realOnmessage?.(msg, extra);
+    };
+
+    const errorsBefore = session.errors.length;
+    const res = await app.fetch(
+      new Request(`http://test/messages?sessionId=${encodeURIComponent(sessionId)}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ foo: 'bar' }),
+      }),
+    );
+    expect(res.status).toBe(202);
+    expect(onmessageCalls).toBe(0);
+    expect(session.errors.length).toBeGreaterThan(errorsBefore);
+
+    await reader.close();
   });
 });

--- a/packages/mcp-server/src/sse-transport.ts
+++ b/packages/mcp-server/src/sse-transport.ts
@@ -23,7 +23,11 @@ import type {
   Transport,
   TransportSendOptions,
 } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { JSONRPCMessage, MessageExtraInfo } from '@modelcontextprotocol/sdk/types.js';
+import {
+  type JSONRPCMessage,
+  JSONRPCMessageSchema,
+  type MessageExtraInfo,
+} from '@modelcontextprotocol/sdk/types.js';
 import type { SSEStreamingApi } from 'hono/streaming';
 
 export interface HonoSseTransportOptions {
@@ -31,6 +35,11 @@ export interface HonoSseTransportOptions {
   /** Path the client should POST follow-up messages to. */
   messageEndpoint: string;
   stream: SSEStreamingApi;
+  /**
+   * Invoked whenever the transport sees inbound or outbound traffic. Used by
+   * the host to update a `lastActivityAt` field for idle-session eviction.
+   */
+  onActivity?: () => void;
 }
 
 export class HonoSseTransport implements Transport {
@@ -42,6 +51,7 @@ export class HonoSseTransport implements Transport {
 
   private readonly stream: SSEStreamingApi;
   private readonly messageEndpoint: string;
+  private readonly onActivity: (() => void) | undefined;
   private closed = false;
   private started = false;
 
@@ -49,6 +59,7 @@ export class HonoSseTransport implements Transport {
     this.sessionId = opts.sessionId;
     this.stream = opts.stream;
     this.messageEndpoint = opts.messageEndpoint;
+    this.onActivity = opts.onActivity;
   }
 
   async start(): Promise<void> {
@@ -65,6 +76,7 @@ export class HonoSseTransport implements Transport {
   async send(message: JSONRPCMessage, _options?: TransportSendOptions): Promise<void> {
     if (this.closed || this.stream.aborted || this.stream.closed) return;
     await this.stream.writeSSE({ event: 'message', data: JSON.stringify(message) });
+    this.onActivity?.();
   }
 
   async close(): Promise<void> {
@@ -83,8 +95,14 @@ export class HonoSseTransport implements Transport {
   /**
    * Feed a JSON-RPC message that arrived via POST /messages into the
    * transport's onmessage callback. Called by the route handler.
+   *
+   * Mirrors the stock `SSEServerTransport.handleMessage()` behaviour from
+   * the MCP SDK: the inbound payload is run through `JSONRPCMessageSchema`
+   * before it ever reaches `onmessage`, so a malformed body surfaces as an
+   * `onerror` event instead of being passed up the stack as a half-typed
+   * value the SDK will trip over.
    */
-  receive(message: JSONRPCMessage, extra?: MessageExtraInfo): void {
+  receive(message: unknown, extra?: MessageExtraInfo): void {
     if (this.closed) {
       this.onerror?.(new Error('Received message on closed SSE transport'));
       return;
@@ -98,6 +116,14 @@ export class HonoSseTransport implements Transport {
       this.onerror?.(new Error('Received message before onmessage handler installed'));
       return;
     }
-    this.onmessage(message, extra);
+    let parsed: JSONRPCMessage;
+    try {
+      parsed = JSONRPCMessageSchema.parse(message);
+    } catch (err) {
+      this.onerror?.(err as Error);
+      return;
+    }
+    this.onActivity?.();
+    this.onmessage(parsed, extra);
   }
 }


### PR DESCRIPTION
Three non-blocking follow-ups to the legacy SSE transport landed in #18. All aimed at making the `/sse` + `/messages` surface safe to expose on a LAN (the Home Assistant addon does exactly that) without piling up sessions or trusting malformed inbound payloads.

## Summary

1. **Cap + idle-evict the SSE session map** in `packages/mcp-server/src/server.ts`.
   - `GET /sse` refuses with `503` + a JSON error body once the session map hits `AULA_MCP_SSE_MAX_SESSIONS` (default `16`).
   - Sessions idle longer than `AULA_MCP_SSE_IDLE_MS` (default `300_000` ms = 5 min) are reaped by a single `setInterval` sweeper started once at boot. `lastActivityAt` is bumped on inbound `POST /messages`, on `transport.receive()`, and on `transport.send()`.
   - Sweeper is `unref()`'d so it can't keep the process alive on its own; the `SIGINT`/`SIGTERM` handler `clearInterval`s it and drains in-flight sessions before `server.stop()` + `mcp.close()`.
   - Shared `closeSseSession()` helper replaces three inline cleanup paths (abort / connect_failed / shutdown).

2. **Pin the "POST after stream torn down but entry not yet swept" race** in `packages/mcp-server/src/sse-transport.test.ts`. Drives the case where the transport has been `close()`'d but the abort handler hasn't yet run `sessions.delete()`. Asserted behaviour: route returns `202` (it does not introspect transport state), the transport short-circuits inside `receive()` because `this.closed === true`, and the failure surfaces as `onerror` — never `onmessage`.

3. **Validate inbound JSON in `HonoSseTransport.receive()`**. Mirrors the stock SDK `SSEServerTransport.handleMessage()` — runs the payload through `JSONRPCMessageSchema.parse()` before calling `onmessage`, and on parse failure surfaces the error via `this.onerror?.(err)` instead of forwarding a half-typed value to `McpServer`. New test feeds `{"foo":"bar"}` and asserts the error path fires.

The test helper now returns `{ app, sessions }` so tests can inspect the transport's error events and force the torn-down race without race-y async timing. Existing tests updated to destructure.

Refs #18.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `bun test packages/mcp-server` — 36 pass, 0 fail (was 34; +2 new tests)
- [x] `bun test` (full suite) — 225 pass, 1 skip, 0 fail
- [x] `pnpm exec biome check packages/mcp-server/src/sse-transport.ts packages/mcp-server/src/sse-transport.test.ts packages/mcp-server/src/server.ts` clean
- [ ] Verify on a real Home Assistant client that the 503 path renders sensibly when the cap is hit (manual smoke; out of scope for CI)

## Notes

- `fix(...)` Conventional-Commit type → release-please will treat this as a patch bump on the next release.
- No new dependencies; uses `JSONRPCMessageSchema` already exported by `@modelcontextprotocol/sdk/types.js`.