### PR TITLE
chore: security updates + supply-chain hardening

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: File issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const today = new Date().toISOString().slice(0, 10);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ github.sha }}
           path: coverage.txt

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           # Tags pushed by GITHUB_TOKEN don't trigger downstream workflows
           # (anti-recursion). Pass a PAT so the tag push fires release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: ./${{ matrix.artifact }} --help | head -5
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
@@ -83,7 +83,7 @@ jobs:
         with:
           fetch-depth: 0  # for accurate release-notes generation
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,10 @@ apps/cli/bin/
 tokens.json
 *.tokens.json
 
-# claude's working notes
+# agent working notes + local worktrees
 .aula-mcp-plan.md
 .claude-scratch/
+.claude/
 
 # editor + os
 .DS_Store

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "includes": ["**", "!**/dist", "!**/build", "!**/coverage", "!aula-python-reference"]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "engines": {
     "node": ">=20.10"
   },
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@11.1.3",
   "scripts": {
     "aula": "bun apps/cli/src/index.ts",
     "mcp": "bun packages/mcp-server/src/server.ts",
@@ -32,13 +32,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
-    "@types/bun": "^1.3.13",
+    "@types/bun": "^1.3.14",
+    "@types/node": "^25.9.1",
+    "bun-types": "^1.3.14",
     "typescript": "^6.0.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@biomejs/biome",
-      "esbuild"
-    ]
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -19,7 +19,7 @@
     "@aula-mcp/aula-auth": "workspace:*",
     "@aula-mcp/aula-client": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "hono": "^4.12.18",
+    "hono": "^4.12.21",
     "qrcode": "^1.5.4",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: ^3.1.2
+  ip-address: ^10.1.1
+
 importers:
 
   .:
@@ -12,8 +16,14 @@ importers:
         specifier: ^2.4.15
         version: 2.4.15
       '@types/bun':
-        specifier: ^1.3.13
-        version: 1.3.13
+        specifier: ^1.3.14
+        version: 1.3.14
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      bun-types:
+        specifier: ^1.3.14
+        version: 1.3.14
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -61,8 +71,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
       hono:
-        specifier: ^4.12.18
-        version: 4.12.18
+        specifier: ^4.12.21
+        version: 4.12.21
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -98,24 +108,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.15':
     resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.15':
     resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.15':
     resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.15':
     resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
@@ -145,11 +159,14 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@types/bun@1.3.13':
-    resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/qrcode-terminal@0.12.2':
     resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
@@ -187,8 +204,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  bun-types@1.3.13:
-    resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -356,8 +373,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -406,6 +423,10 @@ packages:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
+    engines: {node: '>=16.9.0'}
+
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
@@ -424,8 +445,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -664,6 +685,9 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
@@ -782,13 +806,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@types/bun@1.3.13':
+  '@types/bun@1.3.14':
     dependencies:
-      bun-types: 1.3.13
+      bun-types: 1.3.14
 
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
 
   '@types/qrcode-terminal@0.12.2': {}
 
@@ -808,7 +836,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -834,7 +862,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  bun-types@1.3.13:
+  bun-types@1.3.14:
     dependencies:
       '@types/node': 25.6.0
 
@@ -988,7 +1016,7 @@ snapshots:
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -1025,7 +1053,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   finalhandler@2.1.1:
     dependencies:
@@ -1079,6 +1107,8 @@ snapshots:
 
   hono@4.12.18: {}
 
+  hono@4.12.21: {}
+
   htmlparser2@10.1.0:
     dependencies:
       domelementtype: 2.3.0
@@ -1104,7 +1134,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -1331,6 +1361,8 @@ snapshots:
   typescript@6.0.3: {}
 
   undici-types@7.19.2: {}
+
+  undici-types@7.24.6: {}
 
   undici@7.25.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,17 @@
 packages:
   - "packages/*"
   - "apps/*"
+
+# Block packages newer than 2 days — supply-chain safety net. A maliciously
+# published version typically gets reported and yanked well inside this window.
+minimumReleaseAge: 2880
+
+onlyBuiltDependencies:
+  - "@biomejs/biome"
+  - esbuild
+
+# Force patched versions of transitive deps with open CVEs (via
+# @modelcontextprotocol/sdk). Drop these once the SDK bumps them upstream.
+overrides:
+  fast-uri: ^3.1.2
+  ip-address: ^10.1.1


### PR DESCRIPTION
## Summary

- Patches 3 open advisories (2 high, 1 moderate), all transitive through `@modelcontextprotocol/sdk`, via `pnpm.overrides`.
- Adds `pnpm.minimumReleaseAge=2880` (2 days) — refuses to install versions younger than the cooling-off window. Supply-chain safety net.
- Bumps `pnpm` 10.12.1 → 11.1.3 (Corepack-managed).
- Rolls up the open dependabot PRs into one branch.

## Vulnerabilities fixed

| Module | Advisory | Severity | Path |
|---|---|---|---|
| `fast-uri` <=3.1.1 | [CVE-2026-6322](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — host confusion | **HIGH** | `@modelcontextprotocol/sdk > ajv > fast-uri` |
| `fast-uri` <=3.1.0 | [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — path traversal | **HIGH** | `@modelcontextprotocol/sdk > ajv > fast-uri` |
| `ip-address` <=10.1.0 | [CVE-2026-42338](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) — Address6 XSS | MODERATE | `@modelcontextprotocol/sdk > express-rate-limit > ip-address` |

`pnpm audit` after: **No known vulnerabilities found.**

## Other changes

- **pnpm 11 config migration**: pnpm 11 stopped reading the `pnpm` field in `package.json`. Moved `onlyBuiltDependencies` + new `overrides` into `pnpm-workspace.yaml`.
- **Direct dep bumps**: `@types/bun` ^1.3.14, `hono` ^4.12.21 (4.12.22 fails the 2-day rule for now; will roll forward automatically when it ages in).
- **Type-resolution fix**: added `@types/node` + `bun-types` as direct devDeps. pnpm 11's stricter hoisting no longer surfaces them transitively through `@types/bun`, which broke `tsc` resolution of `node:*` imports.
- **GH Actions** (matches dependabot #25–#28): `upload-artifact` v4→v7, `download-artifact` v4→v8, `github-script` v7→v9, `release-please-action` v4→v5.
- `.gitignore`: added `.claude/` — local agent worktrees were poisoning `biome check` with nested root configs.
- `biome.json` schema URL bumped to match installed 2.4.15.

## Supersedes

Closes #25, #26, #27, #28, #29, #30.

## Test plan

- [x] `pnpm install` clean under pnpm 11.1.3
- [x] `pnpm audit` reports zero vulnerabilities
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (4 style infos, no errors)
- [x] `bun test` — 234 pass / 1 skip / 0 fail (same as main)
- [ ] CI runs green on push (Corepack auto-fetches pnpm 11.1.3 from the `packageManager` field)
- [ ] Smoke test the next release-please run — `release-please-action@v5` has a different config schema; we don't pass any inputs so should be a drop-in, but worth eyeballing the first generated PR