### PR TITLE
feat(cli): add `aula ugeplan fetch` for no-LLM week-plan pre-check

### DIFF
--- a/apps/cli/src/commands/ugeplan.test.ts
+++ b/apps/cli/src/commands/ugeplan.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { canonicalItem, normaliseItems } from './ugeplan.ts';
+
+describe('canonicalItem — defined string fields in fixed order', () => {
+  test('keeps defined fields in the canonical key order', () => {
+    const item = canonicalItem({
+      url: 'https://x',
+      content: 'c',
+      childName: 'Theo',
+      subject: 'Matematik',
+    });
+    expect(Object.keys(item)).toEqual(['childName', 'subject', 'content', 'url']);
+  });
+
+  test('drops omitted and empty-string fields', () => {
+    // `title` omitted entirely; `subject` present but empty — both gone.
+    const item = canonicalItem({ childName: 'Theo', subject: '', content: 'c' });
+    expect(item).toEqual({ childName: 'Theo', content: 'c' });
+  });
+
+  test('drops non-string values defensively', () => {
+    // Upstream is typed as strings, but tolerate drift rather than emit junk.
+    const item = canonicalItem({ subject: 42 as unknown as string, content: 'c' });
+    expect(item).toEqual({ content: 'c' });
+  });
+});
+
+describe('normaliseItems — stable ordering for diffing', () => {
+  test('same items in different upstream order serialize identically', () => {
+    const a = normaliseItems([
+      { childName: 'Theo', date: 'mandag', subject: 'Dansk' },
+      { childName: 'Samuel', date: 'tirsdag', subject: 'Idræt' },
+    ]);
+    const b = normaliseItems([
+      { childName: 'Samuel', date: 'tirsdag', subject: 'Idræt' },
+      { childName: 'Theo', date: 'mandag', subject: 'Dansk' },
+    ]);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  test('a genuine content change produces a different serialization', () => {
+    const before = normaliseItems([{ childName: 'Theo', subject: 'Dansk' }]);
+    const after = normaliseItems([{ childName: 'Theo', subject: 'Matematik' }]);
+    expect(JSON.stringify(before)).not.toBe(JSON.stringify(after));
+  });
+
+  test('empty input → empty array', () => {
+    expect(normaliseItems([])).toEqual([]);
+  });
+});

--- a/apps/cli/src/commands/ugeplan.ts
+++ b/apps/cli/src/commands/ugeplan.ts
@@ -1,0 +1,157 @@
+/**
+ * `aula ugeplan fetch` — fetch EasyIQ SkolePortal weekly plans for the
+ * given children and ISO weeks, and print them as deterministic JSON.
+ *
+ * Cheap pre-check for the week-plan poller: diff the normalised items
+ * against a state file and only fire LLM classification when the plan
+ * content actually changed — no SHA, no online hashing service, no LLM
+ * bill. (The previous in-gateway cron asked the model to hash the plan
+ * itself; lacking an exec tool it reached for md5calc.com / hashify /
+ * httpbin, all of which the egress chokepoint held + dropped.)
+ *
+ * Same CLI-not-/tools/invoke rationale as `threads list-ids` /
+ * `notifications list-ids` (see threads.ts / notifications.ts):
+ * openclaw's `/tools/invoke` HTTP surface can't reach MCP-plugin tools,
+ * so a shell poller can't call `aula.ugeplan.easyiq_skoleportal` from
+ * outside the LLM path. This command replicates that tool's context
+ * assembly (guardian id, per-child opaque userIds via getProfilesByLogin,
+ * a WidgetTokenManager) and calls the same EasyIqSkoleportalClient.
+ *
+ * Output is normalised + sorted for stable diffing; the non-deterministic
+ * and sensitive `raw` payload (SkolePortal auth loginIds etc.) is dropped.
+ * Per-child soft failures surface under each week's `warnings` so the
+ * poller can treat a degraded read as "fall through to the LLM"
+ * (fail-open) rather than a clean no-change.
+ *
+ * Scope: easyiq_skoleportal only — that's the provider the household's
+ * schools use (the cron called `aula.ugeplan.easyiq_skoleportal`). Add
+ * sibling subcommands if another provider is ever needed.
+ */
+
+import { AulaHttpClient, withFreshTokens } from '@aula-mcp/aula-auth';
+import {
+  AulaClient,
+  EasyIqSkoleportalClient,
+  isoWeekString,
+  type NormalisedWeekPlanItem,
+  WidgetTokenManager,
+} from '@aula-mcp/aula-client';
+import { fail, fmt, printJson } from '../io.ts';
+import { defaultStore } from '../store.ts';
+
+export interface UgeplanFetchCommandArgs {
+  childIds: number[];
+  institutionCodes: string[];
+  /** ISO weeks to fetch (e.g. ["2026-W23"]). Defaults to current + next. */
+  isoWeeks?: string[];
+}
+
+/** Fixed key order so serialized items are byte-stable across polls. */
+const ITEM_KEYS: ReadonlyArray<keyof NormalisedWeekPlanItem> = [
+  'childName',
+  'date',
+  'subject',
+  'title',
+  'content',
+  'kind',
+  'url',
+];
+
+/**
+ * Reduce a plan item to its defined string fields in a fixed key order.
+ * Drops `undefined`/empty so a field flicking between absent and "" never
+ * reads as a change.
+ */
+export function canonicalItem(it: NormalisedWeekPlanItem): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const k of ITEM_KEYS) {
+    const v = it[k];
+    if (typeof v === 'string' && v.length > 0) out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Canonicalise + order a week's items so the serialized output is
+ * byte-stable regardless of upstream ordering jitter — the whole point of
+ * the pre-check is that an unchanged plan diffs to "unchanged".
+ */
+export function normaliseItems(items: NormalisedWeekPlanItem[]): Record<string, string>[] {
+  return items.map(canonicalItem).sort((a, b) => (JSON.stringify(a) < JSON.stringify(b) ? -1 : 1));
+}
+
+/** Current + next ISO week — mirrors the old cron's "this week + next week". */
+function defaultWeeks(): string[] {
+  const now = new Date();
+  const next = new Date(now.getTime() + 7 * 86_400_000);
+  return [isoWeekString(now), isoWeekString(next)];
+}
+
+export async function runUgeplanFetch(args: UgeplanFetchCommandArgs): Promise<void> {
+  const store = defaultStore();
+  const http = new AulaHttpClient();
+  let record: Awaited<ReturnType<typeof withFreshTokens>>;
+  try {
+    record = await withFreshTokens({ store, http });
+  } catch (e) {
+    printJson({
+      ok: false,
+      error: 'tokens',
+      message: (e as Error).message,
+      hint: `Run ${fmt.bold('aula login')} or ${fmt.bold('aula refresh-stepup')} to recover.`,
+    });
+    process.exit(1);
+  }
+
+  const client = new AulaClient({ tokens: record.tokens, http });
+  try {
+    // Prime the guardian profile (the *ForActiveProfile endpoints 403
+    // otherwise) and grab the numeric guardian id — same preflight the
+    // MCP path does via context.getGuardianUserId().
+    const guardianCtx = await client.getProfileContext('guardian');
+    const guardianId = guardianCtx.userId == null ? '' : String(guardianCtx.userId);
+
+    // SkolePortal's x-childfilter wants the opaque per-child userId, not
+    // the numeric child id. Map it from the profiles list, aligned with
+    // childIds by index (missing → ""), exactly as buildIntegrationCtx does.
+    const profilesData = await client.getProfilesByLogin();
+    const userIdByChildId = new Map<number, string>();
+    for (const profile of profilesData.profiles ?? []) {
+      for (const child of profile.children ?? []) {
+        if (child.userId != null) userIdByChildId.set(child.id, String(child.userId));
+      }
+    }
+    const childUserIds = args.childIds.map((id) => userIdByChildId.get(id) ?? '');
+
+    const widgets = new WidgetTokenManager({ client });
+    const sp = new EasyIqSkoleportalClient({ http, widgets });
+
+    const isoWeeks = args.isoWeeks && args.isoWeeks.length > 0 ? args.isoWeeks : defaultWeeks();
+
+    const weeks: Record<string, { items: Record<string, string>[]; warnings?: string[] }> = {};
+    for (const isoWeek of isoWeeks) {
+      const plan = await sp.getWeekPlan({
+        isoWeek,
+        sessionId: record.username,
+        guardianId,
+        childIds: args.childIds,
+        childUserIds,
+        institutionCodes: args.institutionCodes,
+      });
+      const items = normaliseItems(plan.items);
+      weeks[isoWeek] = {
+        items,
+        ...(plan.warnings && plan.warnings.length > 0 ? { warnings: plan.warnings } : {}),
+      };
+    }
+    printJson({ ok: true, weeks });
+  } catch (e) {
+    printJson({
+      ok: false,
+      error: 'api',
+      message: (e as Error).message,
+    });
+    fail((e as Error).message);
+    process.exit(1);
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -25,6 +25,7 @@ import { runStatus } from './commands/status.ts';
 import { runThreadFetch, runThreadsListIds } from './commands/threads.ts';
 import { runTokensExport, runTokensImport } from './commands/tokens.ts';
 import { runTranscriptList, runTranscriptPrune, runTranscriptView } from './commands/transcript.ts';
+import { runUgeplanFetch } from './commands/ugeplan.ts';
 import { runWhoami } from './commands/whoami.ts';
 import { fmt } from './io.ts';
 import { parseArgs } from './parse-args.ts';
@@ -42,6 +43,7 @@ ${fmt.bold('Usage')}:
   aula tokens export <dir>
   aula tokens import <dir>
   aula threads list-ids [--page-size N] [--json]
+  aula ugeplan fetch --child-ids <csv> --institution-codes <csv> [--iso-weeks <csv>]
   aula thread fetch <id> [--page N]
   aula transcript list [--json]
   aula transcript view <file> [--json]
@@ -154,6 +156,56 @@ async function main(): Promise<void> {
         default:
           process.stderr.write(`Unknown threads subcommand: ${sub ?? '<missing>'}\n`);
           process.stderr.write('Try: aula threads list-ids [--page-size N]\n');
+          process.exit(2);
+      }
+      break;
+    }
+    case 'ugeplan': {
+      const sub = args.positional[0];
+      switch (sub) {
+        case 'fetch': {
+          const childIdsRaw = args.flags['child-ids'] ?? args.flags.childIds;
+          const instRaw = args.flags['institution-codes'] ?? args.flags.institutionCodes;
+          const weeksRaw = args.flags['iso-weeks'] ?? args.flags.isoWeeks;
+          const childIds =
+            typeof childIdsRaw === 'string'
+              ? childIdsRaw
+                  .split(',')
+                  .map((s) => Number.parseInt(s.trim(), 10))
+                  .filter((n) => Number.isFinite(n) && n > 0)
+              : [];
+          const institutionCodes =
+            typeof instRaw === 'string'
+              ? instRaw
+                  .split(',')
+                  .map((s) => s.trim())
+                  .filter((s) => s.length > 0)
+              : [];
+          const isoWeeks =
+            typeof weeksRaw === 'string'
+              ? weeksRaw
+                  .split(',')
+                  .map((s) => s.trim())
+                  .filter((s) => s.length > 0)
+              : undefined;
+          if (childIds.length === 0 || institutionCodes.length === 0) {
+            process.stderr.write(
+              'Usage: aula ugeplan fetch --child-ids <csv> --institution-codes <csv> [--iso-weeks <csv>]\n',
+            );
+            process.exit(2);
+          }
+          await runUgeplanFetch({
+            childIds,
+            institutionCodes,
+            ...(isoWeeks ? { isoWeeks } : {}),
+          });
+          break;
+        }
+        default:
+          process.stderr.write(`Unknown ugeplan subcommand: ${sub ?? '<missing>'}\n`);
+          process.stderr.write(
+            'Try: aula ugeplan fetch --child-ids <csv> --institution-codes <csv> [--iso-weeks <csv>]\n',
+          );
           process.exit(2);
       }
       break;


### PR DESCRIPTION
## What

Adds `aula ugeplan fetch --child-ids <csv> --institution-codes <csv> [--iso-weeks <csv>]` — a cheap CLI path to the **EasyIQ SkolePortal** weekly plan, mirroring the existing `aula threads list-ids` pre-check command.

```
aula ugeplan fetch --child-ids 123,456 --institution-codes G12345,G12345
```
→ `{ "ok": true, "weeks": { "2026-W23": { "items": [...] }, "2026-W24": { "items": [...] } } }`

## Why

It lets a shell poller answer "did the weekly plan change?" **without an LLM round-trip**. As with `threads list-ids`, the MCP `/tools/invoke` surface doesn't expose plugin tools, so the only off-LLM way to read the ugeplan integration is a dedicated subcommand. Polling for plan changes through a full agent turn is wasteful (and tempts a model with no exec tool into reaching for online hash calculators to diff the content).

## How

`runUgeplanFetch` mirrors the MCP tool's context assembly:
- prime the guardian profile + read the numeric guardian id (`getProfileContext('guardian')`)
- map each numeric `childId` → opaque per-child `userId` via `getProfilesByLogin()` (SkolePortal's `x-childfilter` needs the opaque token)
- build a `WidgetTokenManager` + `EasyIqSkoleportalClient` and call `getWeekPlan()` per requested ISO week (default: current + next)

Output is **normalised + sorted** for byte-stable diffing across polls; the non-deterministic, sensitive `raw` payload (SkolePortal auth `loginId`s) is dropped. Per-child soft failures surface under each week's `warnings`, so a degraded read can fall through to the caller's LLM path (fail-open) rather than read as a clean no-change.

Scope is `easyiq_skoleportal` (widget 0128). Sibling subcommands can follow for the other providers.

## Tests

`apps/cli/src/commands/ugeplan.test.ts` covers `canonicalItem` (fixed key order, drops empties/non-strings) and `normaliseItems` (order-independent serialization; genuine changes still differ). `tsc`, `biome check`, and `bun test` pass; `bun build --compile` smoke-tested (help, usage error, unknown subcommand).

> Note: this builds on the EasyIQ SkolePortal integration already in `main`. It does not depend on any downstream-only commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)