### PR TITLE
fix(auth,meebook): MitID hardware kodeviser login + dup identities + Meebook unilogin

### DIFF
--- a/packages/aula-auth/src/aula-saml-flow.test.ts
+++ b/packages/aula-auth/src/aula-saml-flow.test.ts
@@ -105,6 +105,27 @@ describe('parseIdentitySelectionPage', () => {
     expect(formInputs.csrf).toBe('x');
   });
 
+  test('does not duplicate identities when anchors are wrapped in list-link-box', () => {
+    // The live page wraps each anchor in a `div.list-link-box`; the selector
+    // matches both the box and its nested anchor. Each identity must appear once.
+    const wrapped = `
+      <form><input type="hidden" name="csrf" value="x" /></form>
+      <div class="list-link-box">
+        <a class="list-link" data-loginoptions='{"id":"1","name":"Child A"}'>
+          <div class="list-link-text">Child A (Forælder)</div>
+        </a>
+      </div>
+      <div class="list-link-box">
+        <a class="list-link" data-loginoptions='{"id":"2","name":"Child B"}'>
+          <div class="list-link-text">Child B (Forælder)</div>
+        </a>
+      </div>`;
+    const { options } = parseIdentitySelectionPage(wrapped);
+    expect(options).toHaveLength(2);
+    expect(options.map((o) => o.name)).toEqual(['Child A (Forælder)', 'Child B (Forælder)']);
+    expect(options.map((o) => o.index)).toEqual([1, 2]);
+  });
+
   test('throws when no identity options are present', () => {
     expect(() => parseIdentitySelectionPage('<html></html>')).toThrow(AulaSamlError);
   });

--- a/packages/aula-auth/src/aula-saml-flow.ts
+++ b/packages/aula-auth/src/aula-saml-flow.ts
@@ -136,11 +136,20 @@ export function parseIdentitySelectionPage(html: string): {
   // We can't easily get aligned arrays from extractAllAttr because the labels
   // live in a child div, so use cheerio directly here.
   const $ = cheerio.load(html);
+  // The live page wraps each `a.list-link` inside a `div.list-link-box`, so
+  // this selector matches both the container *and* its nested anchor — and
+  // each identity would be yielded twice (the duplicated-list bug). Dedupe on
+  // the underlying anchor element so every identity is emitted exactly once.
+  // Bare anchors (no wrapping box, as in our fixtures) still match once.
+  const seenAnchors = new Set<unknown>();
   $('a.list-link, div.list-link-box').each((_: number, el) => {
     const $el = $(el);
     const $a = $el.is('a') ? $el : $el.find('a').first();
+    const anchor = $a.get(0);
+    if (!anchor || seenAnchors.has(anchor)) return;
     const json = $a.attr('data-loginoptions');
     if (!json) return;
+    seenAnchors.add(anchor);
     optionsJson.push(json);
     const labelEl = $el.find('div.list-link-text').first();
     labels.push(labelEl.length ? labelEl.text().trim() : `Option ${optionsJson.length}`);

--- a/packages/aula-auth/src/mitid-client.test.ts
+++ b/packages/aula-auth/src/mitid-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { Buffer } from 'node:buffer';
 import { MitidError, parseAuxResponse } from './mitid-client.ts';
+import { normalizeAuthenticatorType } from './mitid-types.ts';
 
 describe('parseAuxResponse', () => {
   function buildAuxBody(inner: unknown): string {
@@ -60,5 +61,17 @@ describe('parseAuxResponse', () => {
   test('throws when checksum or sessionId missing', () => {
     const body = buildAuxBody({ coreClient: {}, parameters: {} });
     expect(() => parseAuxResponse(body)).toThrow(MitidError);
+  });
+});
+
+describe('normalizeAuthenticatorType', () => {
+  test('maps the server\'s "TOKEN" (hardware kodeviser) to CODE_TOKEN', () => {
+    expect(normalizeAuthenticatorType('TOKEN')).toBe('CODE_TOKEN');
+  });
+
+  test('passes APP, PASSWORD and CODE_TOKEN through unchanged', () => {
+    expect(normalizeAuthenticatorType('APP')).toBe('APP');
+    expect(normalizeAuthenticatorType('PASSWORD')).toBe('PASSWORD');
+    expect(normalizeAuthenticatorType('CODE_TOKEN')).toBe('CODE_TOKEN');
   });
 });

--- a/packages/aula-auth/src/mitid-client.ts
+++ b/packages/aula-auth/src/mitid-client.ts
@@ -41,7 +41,11 @@ import type {
   NextAuthenticatorResponse,
   SrpInitResponse,
 } from './mitid-types.ts';
-import { AUTHENTICATOR_TO_COMBINATION_ID, COMBINATION_ID_TO_AUTHENTICATOR } from './mitid-types.ts';
+import {
+  AUTHENTICATOR_TO_COMBINATION_ID,
+  COMBINATION_ID_TO_AUTHENTICATOR,
+  normalizeAuthenticatorType,
+} from './mitid-types.ts';
 import { mitidUrls } from './mitid-urls.ts';
 import { CustomSrp } from './srp.ts';
 
@@ -636,7 +640,9 @@ export class MitidClient {
   }
 
   private applyNextAuthenticator(next: NextAuthenticator): void {
-    const human = next.authenticatorType as MitidAuthenticatorType;
+    // The server may use a different label than our human type — notably it
+    // returns `TOKEN` for the hardware kodeviser, which we call `CODE_TOKEN`.
+    const human = normalizeAuthenticatorType(next.authenticatorType);
     this.currentAuthenticatorType = human;
     this.currentAuthenticatorSessionFlowKey = next.authenticatorSessionFlowKey;
     this.currentAuthenticatorEafeHash = next.eafeHash;

--- a/packages/aula-auth/src/mitid-types.ts
+++ b/packages/aula-auth/src/mitid-types.ts
@@ -30,6 +30,25 @@ export const AUTHENTICATOR_TO_COMBINATION_ID: Readonly<Record<MitidAuthenticator
     PASSWORD: '', // reached implicitly after CODE_TOKEN
   });
 
+/**
+ * Normalize the server's raw `authenticatorType` string into our human type.
+ *
+ * The MitID backend labels the hardware code generator ("kodeviser") as
+ * `TOKEN`, while we call it `CODE_TOKEN` everywhere (matching Aula's UI and
+ * the combination-id table above). Without this, an account that logs in with
+ * a physical kodeviser gets `currentAuthenticatorType = 'TOKEN'`, and the
+ * `selectAuthenticator('CODE_TOKEN')` guard then throws because the strings
+ * don't match.
+ *
+ * `APP` and `PASSWORD` pass through unchanged. Unknown values are returned
+ * as-is (cast), so a genuinely new authenticator surfaces loudly downstream
+ * rather than being silently swallowed.
+ */
+export function normalizeAuthenticatorType(raw: string): MitidAuthenticatorType {
+  if (raw === 'TOKEN') return 'CODE_TOKEN';
+  return raw as MitidAuthenticatorType;
+}
+
 /** Returned by `GET /authentication-sessions/{id}` on construction. */
 export interface AuthenticationSessionResponse {
   brokerSecurityContext: string;

--- a/packages/aula-client/src/integrations/integrations.test.ts
+++ b/packages/aula-client/src/integrations/integrations.test.ts
@@ -185,6 +185,22 @@ describe('MeebookClient.getWeekPlan', () => {
     expect(http.requested[0]?.headers?.sessionuuid).toBe('cj');
     expect(http.requested[0]?.headers?.['x-version']).toBe('1.0');
   });
+
+  test('childFilter[] uses the per-child unilogin, not the numeric child id', async () => {
+    const http = new FakeHttp().enqueue({ status: 200, body: '[]' });
+    const client = new MeebookClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
+    await client.getWeekPlan(ctx({ childIds: [111293], childUserIds: ['thit0305'] }));
+    const url = http.requested[0]?.url ?? '';
+    expect(url).toContain('childFilter%5B%5D=thit0305');
+    expect(url).not.toContain('111293');
+  });
+
+  test('falls back to the numeric child id when no unilogin was resolved', async () => {
+    const http = new FakeHttp().enqueue({ status: 200, body: '[]' });
+    const client = new MeebookClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
+    await client.getWeekPlan(ctx({ childIds: [111293], childUserIds: [''] }));
+    expect(http.requested[0]?.url ?? '').toContain('childFilter%5B%5D=111293');
+  });
 });
 
 // --------------------------------------------------------------------------

--- a/packages/aula-client/src/integrations/meebook.ts
+++ b/packages/aula-client/src/integrations/meebook.ts
@@ -65,7 +65,16 @@ export class MeebookClient {
       const params = new URLSearchParams();
       params.set('currentWeekNumber', ctx.isoWeek);
       params.set('userProfile', 'guardian');
-      for (const cid of ctx.childIds) params.append('childFilter[]', String(cid));
+      // Meebook keys `childFilter[]` on the child's unilogin (e.g. "thit0305"),
+      // NOT the numeric Aula child profile id — passing the number yields a
+      // 400 "Fandt et unilogin i child filter med et ugyldigt format". Prefer
+      // the per-child opaque userId (aligned by index); fall back to the
+      // numeric id only when no userId was resolved for that child.
+      for (let i = 0; i < ctx.childIds.length; i++) {
+        const userId = ctx.childUserIds?.[i];
+        const filter = userId && userId.length > 0 ? userId : String(ctx.childIds[i]);
+        params.append('childFilter[]', filter);
+      }
       for (const code of ctx.institutionCodes) params.append('institutionFilter[]', code);
       const url = `${MEEBOOK_BASE}?${params.toString()}`;
       const res = await this.http.request(url, {


### PR DESCRIPTION
## What

Three independent bugs, all surfaced by a user (**Ole Sandum**, thanks!) logging in with a **MitID hardware code generator ("kodeviser")** who still couldn't read the weekly plan. Each fix is small, low-risk, and unit-tested.

### 1. MitID hardware kodeviser can't log in
The MitID backend returns `TOKEN` as the `authenticatorType` for the hardware kodeviser, but the client only knew `CODE_TOKEN`. `applyNextAuthenticator` cast the raw server string, so `selectAuthenticator('CODE_TOKEN')` then saw `TOKEN !== CODE_TOKEN` and threw `MitidAuthenticatorUnavailableError`.

→ Added `normalizeAuthenticatorType` (`TOKEN` → `CODE_TOKEN`; `APP`/`PASSWORD` pass through; unknowns surface loudly) and apply it in `applyNextAuthenticator`.

### 2. Identity list duplicated on multi-child accounts
The live `/loginoption` page wraps each `a.list-link` in a `div.list-link-box`, so the selector `'a.list-link, div.list-link-box'` matched **both** the container and its nested anchor — every identity was listed twice (1&2 identical, 3&4 identical, …). Tests only had bare anchors, so they passed.

→ Dedupe on the underlying anchor element.

### 3. Meebook ugeplan returns HTTP 400 (the actual "no ugeplan" blocker)
`childFilter[]` was sent the numeric Aula child profile id, but Meebook keys on the child's **unilogin** (e.g. `thit0305`) and rejects the number with `400 "Fandt et unilogin i child filter med et ugyldigt format"`. The context already computes the per-child unilogin (`childUserIds`) — only SkolePortal used it.

→ Meebook now uses `ctx.childUserIds`, falling back to the numeric id when none was resolved.

## Tests
- `normalizeAuthenticatorType`: `TOKEN`→`CODE_TOKEN`, others pass through.
- `parseIdentitySelectionPage`: wrapped-in-`list-link-box` page yields each identity once.
- Meebook: `childFilter[]` carries the unilogin; falls back to numeric id when unilogin missing.

Full suite green (253 pass), `tsc` + `biome check` clean.

## Not included
Ole also reported `aula.calendar.events` 403 — a separate **guidance** bug (`discover.ts` tells the agent to use `child.userId` for `profileIds`, but calendar wants the institution-profile id, exposed as `children[].institution.id`). Held back pending live verification of the field mapping.

Diagnosed by Ole Sandum.