### PR TITLE
docs: document the stdio transport for local clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,25 @@ Så kan du bare spørge naturligt — børnenes navne bliver fuzzy-matched mod `
 
 Claude kalder `aula.discover` én gang, vælger den rigtige ugeplan-vendor for din skole ud fra `detectedWidgets`, og svarer på dansk med dansk-formatterede datoer.
 
+### stdio i stedet for HTTP
+
+`pnpm mcp` starter en HTTP-server på en port. Der findes også en **stdio-transport** med præcis samme værktøjer, hvor klienten selv starter processen. Ingen port, ingen daemon, intet der lytter på loopback:
+
+```sh
+claude mcp add aula -- bun /absolut/sti/til/aula-mcp/packages/mcp-server/src/server-stdio.ts
+```
+
+Fra repo-roden virker `pnpm mcp:stdio` også. Bemærk at stdout er JSON-RPC-kanalen. pnpm's `$ <kommando>`-banner går til stderr, så det forstyrrer ikke.
+
+De HTTP-specifikke variabler (`AULA_MCP_PORT`, `AULA_MCP_HOST`, `AULA_MCP_ALLOW_REMOTE`) ignoreres her. `AULA_MCP_DIR`, `AULA_MCP_KEY`, `AULA_MCP_WRITE` og `AULA_MCP_RAW` virker som normalt, plus `AULA_MCP_LOG=1` for logs på stderr.
+
+> Kører klienten på samme maskine som serveren, er stdio det simpleste valg. Skal serveren derimod køre et andet sted, fx Home Assistant, en Pi eller en VPS, er HTTP det rigtige. Se [Self-hosting](#self-hosting).
+
 ### Claude Desktop
 
 Drop snippet'et fra [`examples/claude-config/claude-desktop.json`](./examples/claude-config/claude-desktop.json) ind i `~/Library/Application Support/Claude/claude_desktop_config.json`.
+
+Claude Desktop kan også selv starte serveren over stdio, så du slipper for at have `pnpm mcp` kørende i et terminalvindue. Brug [`examples/claude-config/claude-desktop-stdio.json`](./examples/claude-config/claude-desktop-stdio.json) og ret stien til dit eget checkout.
 
 ### claude.ai (web)
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Drop snippet'et fra [`examples/claude-config/claude-desktop.json`](./examples/cl
 
 Claude Desktop kan også selv starte serveren over stdio, så du slipper for at have `pnpm mcp` kørende i et terminalvindue. Brug [`examples/claude-config/claude-desktop-stdio.json`](./examples/claude-config/claude-desktop-stdio.json) og ret stien til dit eget checkout.
 
+Brug den fulde sti til `bun` (`which bun`) i stedet for bare `bun`. Claude Desktop startes fra Finder og arver ikke din shell-`PATH`, så `~/.bun/bin` er typisk ikke med — serveren starter bare ikke, uden nogen tydelig fejl.
+
 ### claude.ai (web)
 
 Web-UI'et kræver en offentlig HTTPS-URL — `127.0.0.1` virker ikke, fordi forbindelsen sker server-side fra Anthropic's cloud. Til en hurtig test:

--- a/examples/claude-config/README.md
+++ b/examples/claude-config/README.md
@@ -1,6 +1,6 @@
 # Wiring aula-mcp into Claude Code / Claude Desktop
 
-The MCP server speaks Streamable HTTP and listens on `http://127.0.0.1:7878/mcp` by default. Both Claude Code and Claude Desktop accept HTTP transports.
+The MCP server ships two transports. **Streamable HTTP** listens on `http://127.0.0.1:7878/mcp` by default and suits setups where the server runs somewhere other than the client (Home Assistant, a Pi, a VPS). **stdio** lets the client spawn the process itself, with no port and no daemon, which is the simpler choice when client and server share a machine. Both expose the same tools.
 
 ## Claude Code (CLI)
 
@@ -14,10 +14,22 @@ See [`claude-code.json`](./claude-code.json) for a copy-pasteable snippet.
 
 See [`claude-desktop.json`](./claude-desktop.json).
 
+## stdio
+
+Point the client at `packages/mcp-server/src/server-stdio.ts` and it starts the server on demand:
+
+```sh
+claude mcp add aula -- bun /absolute/path/to/aula-mcp/packages/mcp-server/src/server-stdio.ts
+```
+
+For Claude Desktop, see [`claude-desktop-stdio.json`](./claude-desktop-stdio.json) and correct the path to your own checkout.
+
+`pnpm mcp:stdio` works too when run from the repo root. stdout carries JSON-RPC, so nothing else may write to it. pnpm's own `$ <command>` banner goes to stderr and is therefore harmless. Set `AULA_MCP_LOG=1` for server logs (also stderr). The HTTP-only variables (`AULA_MCP_PORT`, `AULA_MCP_HOST`, `AULA_MCP_ALLOW_REMOTE`) are ignored on this transport.
+
 ## Prerequisites
 
 1. Run `pnpm --filter @aula-mcp/cli dev login` once to authenticate.
-2. Start the server: `pnpm --filter @aula-mcp/mcp-server dev`.
+2. Start the server: `pnpm --filter @aula-mcp/mcp-server dev`. On stdio you can skip this entirely, since the client spawns it.
 3. Restart your MCP client.
 
 ## What the agent should do first

--- a/examples/claude-config/README.md
+++ b/examples/claude-config/README.md
@@ -24,6 +24,12 @@ claude mcp add aula -- bun /absolute/path/to/aula-mcp/packages/mcp-server/src/se
 
 For Claude Desktop, see [`claude-desktop-stdio.json`](./claude-desktop-stdio.json) and correct the path to your own checkout.
 
+That example uses a bare `bun` as the command, which relies on `bun` being on the spawned process's `PATH`. Claude Code inherits your shell's, so it just works. Claude Desktop on macOS does not — a GUI-launched app gets a minimal `PATH` that usually excludes `~/.bun/bin`, and the server fails to start with no obvious reason. Run `which bun` and use the absolute path there instead:
+
+```json
+"command": "/Users/you/.bun/bin/bun"
+```
+
 `pnpm mcp:stdio` works too when run from the repo root. stdout carries JSON-RPC, so nothing else may write to it. pnpm's own `$ <command>` banner goes to stderr and is therefore harmless. Set `AULA_MCP_LOG=1` for server logs (also stderr). The HTTP-only variables (`AULA_MCP_PORT`, `AULA_MCP_HOST`, `AULA_MCP_ALLOW_REMOTE`) are ignored on this transport.
 
 ## Prerequisites

--- a/examples/claude-config/claude-desktop-stdio.json
+++ b/examples/claude-config/claude-desktop-stdio.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "aula": {
+      "command": "bun",
+      "args": ["/absolute/path/to/aula-mcp/packages/mcp-server/src/server-stdio.ts"]
+    }
+  }
+}


### PR DESCRIPTION
`server-stdio.ts` har været med siden SSE-arbejdet, men er ikke nævnt i README eller i nogen af eksempel-konfigurationerne. Alle peger på HTTP-transporten, også når klient og server kører på samme maskine, hvor stdio er den enklere løsning.

Det rammer især den lokale LLM-opsætning som README allerede anbefaler i data-flow-disclaimeren. Følger man rådet til LM Studio eller Ollama, ender man alligevel med en lyttende server.

Tilføjer et stdio-afsnit i README, et tilsvarende i `examples/claude-config/README.md`, og `claude-desktop-stdio.json` som modstykke til det eksisterende HTTP-snippet.

Kun dokumentation, ingen kodeændringer. `pnpm typecheck`, `pnpm lint` og `bun test` er grønne (259 pass, 1 skip, 0 fail). Baggrund i commit-beskeden.
