### PR TITLE
fix(mcp-server): set idleTimeout on the setup UI server

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -249,6 +249,10 @@ if (INGRESS_PORT_RAW) {
     // all interfaces — the addon container's network namespace already isolates
     // the port from the LAN unless config.yaml exposes it via `ports:`.
     hostname: '0.0.0.0',
+    // Same reason as the MCP server above: the setup UI streams login
+    // progress over SSE, and Bun's 10 s default closes it mid-flow. The
+    // browser loses the QR refreshes and the login never completes.
+    idleTimeout: 240,
     fetch: setupApp.fetch,
   });
   logger.info('aula-mcp.setup_ui.listening', { port: ingressPort });


### PR DESCRIPTION
The MCP server sets `idleTimeout: 240` with a comment explaining that the SSE stream stays open across a session and Bun's 10 s default closes it mid-flight. The setup UI server started a few lines below never got the same setting.

That server streams the entire MitID login to the browser over SSE: QR refreshes, channel-verified, the identity picker, and success. Bun closes the connection after 10 seconds, `emit()` fails, and the login aborts. Bun says so directly:

```
[Bun.serve]: request timed out after 10 seconds. Pass `idleTimeout` to configure.
```

A MitID login takes well over 10 seconds, so the flow never reached `store.save()` and no tokens were written.

**Verified against a real login** on macOS 15, Bun 1.3.14. Before: the warning appears and `~/.config/aula-mcp/tokens.json` is never created. After: the flow runs through the identity picker and stores tokens. 240 s matches the MCP server so both have one idle policy.

One line. `pnpm typecheck`, `pnpm lint` and `bun test` are green (259 pass, 1 skip, 0 fail).
