### PR TITLE
fix(cli): tell the user to open the MitID app while waiting

### DIFF
--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -92,6 +92,9 @@ export async function runLogin(args: LoginCommandArgs): Promise<void> {
         return choice;
       },
       appCallbacks: {
+        onWaiting() {
+          info('Open your MitID app to continue. QR codes appear once it connects.');
+        },
         onOtp(otp) {
           info(`Enter this OTP in your MitID app: ${fmt.bold(otp)}`);
         },

--- a/packages/aula-auth/src/mitid-client.ts
+++ b/packages/aula-auth/src/mitid-client.ts
@@ -128,6 +128,17 @@ export function parseAuxResponse(rawBody: string | { Aux?: string }): MitidAuxDa
 }
 
 export interface AppAuthCallbacks {
+  /**
+   * Fired once, as soon as the app-auth session is armed and before the
+   * first poll.
+   *
+   * Nothing happens in this phase until the user opens the MitID app, so a
+   * caller with no output here looks like a hung process. It must fire
+   * before polling starts, not on the first `waiting` result: the first
+   * poll is a long-poll that blocks for ~25 s, which is long past the point
+   * where the user has already concluded the process is stuck.
+   */
+  onWaiting?: () => void | Promise<void>;
   onOtp?: (otp: string) => void | Promise<void>;
   /** Called every time a new pair of QR JSON payloads is received. */
   onQr?: (qr: { qr1Json: string; qr2Json: string; updateCount: number }) => void | Promise<void>;
@@ -409,6 +420,7 @@ export class MitidClient {
     const deadline = Date.now() + maxPollMs;
 
     await this.startAppAuth();
+    await callbacks.onWaiting?.();
 
     while (true) {
       if (opts.signal?.aborted) throw new MitidError('APP poll aborted by caller');


### PR DESCRIPTION
The APP login flow polls until the user opens MitID on their phone. Until then the CLI printed its last line and went quiet:

```
? MitID username: <name>
• Starting MitID login for <name> (APP)
```

That is the entire output, for minutes, while the process is healthy and just waiting for a phone. It reads as a hang. The README documents the symptom under Fejlfinding, so the cause is already known.

Adds `onWaiting` to `AppAuthCallbacks` and wires the CLI:

```
• Starting MitID login for <name> (APP)
• Open your MitID app to continue. QR codes appear once it connects.
```

**On the placement:** it fires right after `startAppAuth()` arms the session, not on the first `waiting` poll result. I tried the latter first and it was wrong. MitID's first poll is a long-poll that blocks for around 25 seconds, so the hint landed well after the user had already given up. Arming the session is also the more accurate moment, since that is when MitID starts waiting for the app.

The setup UI shows its own progress and is untouched; the callback is available if it ever wants it.

No test for the loop: `MitidClient` has a private constructor, so exercising it needs HTTP mocking, and the note on `mitid-poll-machine.ts` says the pure interpreter exists precisely so the loop does not have to be tested directly. Verified by hand against a real MitID login.

`pnpm typecheck`, `pnpm lint` and `bun test` are green (262 pass, 1 skip, 0 fail).
