### PR TITLE
fix: correct AulaProfile field names, and probe a widget the profile has

### DIFF
--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -68,14 +68,15 @@ export async function runDoctor(args: DoctorCommandArgs = {}): Promise<void> {
 
   let guardianUserId: string | null = null;
   let childIds: number[] = [];
+  let detectedWidgets: string[] = [];
 
   await runCheck(checks, 'profiles.getProfileContext', async () => {
     const data = await client.getProfileContext('guardian');
     guardianUserId = data.userId == null ? null : String(data.userId);
-    const widgetIds = (data.pageConfiguration?.widgetConfigurations ?? [])
+    detectedWidgets = (data.pageConfiguration?.widgetConfigurations ?? [])
       .map((w) => w.widget?.widgetId ?? w.widgetId)
       .filter((id): id is string => typeof id === 'string' && id.length > 0);
-    return `userId=${guardianUserId ?? 'missing'}, widgets=[${widgetIds.join(',') || 'none'}]`;
+    return `userId=${guardianUserId ?? 'missing'}, widgets=[${detectedWidgets.join(',') || 'none'}]`;
   });
 
   await runCheck(checks, 'collect child IDs', async () => {
@@ -121,9 +122,15 @@ export async function runDoctor(args: DoctorCommandArgs = {}): Promise<void> {
     return `received (${typeof data}; ${JSON.stringify(data).length} chars)`;
   });
 
-  await runCheck(checks, 'aulaToken.getAulaToken (widget 0001 / EasyIQ)', async () => {
-    const t = await client.getWidgetToken('0001');
-    return `widget token issued (${t.length} chars)`;
+  // Ask for a token for a widget this profile actually has. Hardcoding
+  // 0001 (EasyIQ) made doctor report a failure on every school that uses a
+  // different vendor: Aula answers 400 for a widget you were never granted,
+  // which is correct behaviour, not a fault worth flagging.
+  await runCheck(checks, 'aulaToken.getAulaToken', async () => {
+    const widgetId = detectedWidgets[0];
+    if (!widgetId) return 'skipped — no widgets on this profile';
+    const t = await client.getWidgetToken(widgetId);
+    return `widget ${widgetId}: token issued (${t.length} chars)`;
   });
 
   // ---- output -----------------------------------------------------------------

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -70,7 +70,7 @@ export async function runWhoami(args: WhoamiCommandArgs = {}): Promise<void> {
       info(`Guardian user-id (used by integrations): ${guardianUserId}`);
     }
     for (const profile of profilesData.profiles ?? []) {
-      info(`Profile: ${fmt.bold(profile.name)} (id ${profile.id})`);
+      info(`Profile: ${fmt.bold(profile.displayName)} (id ${profile.profileId})`);
       for (const child of profile.children ?? []) {
         const inst = child.institutionProfile?.institutionName ?? '?';
         const code = child.institutionProfile?.institutionCode ?? '?';

--- a/packages/aula-client/src/aula-client.test.ts
+++ b/packages/aula-client/src/aula-client.test.ts
@@ -88,11 +88,16 @@ describe('AulaClient API method wrappers', () => {
     // wrapper makes its own call — two requests in total.
     http.enqueue(
       { status: 200, body: envelope({ profiles: [] }) }, // probe
-      { status: 200, body: envelope({ profiles: [{ id: 1, name: 'Casper' }] }) }, // actual call
+      // Field names match what Aula actually returns: profileId/displayName.
+      {
+        status: 200,
+        body: envelope({ profiles: [{ profileId: 1, displayName: 'Casper' }] }),
+      }, // actual call
     );
     const c = makeClient(http);
     const data = await c.getProfilesByLogin();
-    expect(data.profiles?.[0]?.name).toBe('Casper');
+    expect(data.profiles?.[0]?.displayName).toBe('Casper');
+    expect(data.profiles?.[0]?.profileId).toBe(1);
     expect(http.requested[1]?.url).toMatch(/method=profiles\.getProfilesByLogin/);
     expect(http.requested[1]?.url).toMatch(/access_token=TEST_AT/);
   });

--- a/packages/aula-client/src/aula-types.ts
+++ b/packages/aula-client/src/aula-types.ts
@@ -40,8 +40,11 @@ export interface AulaInstitutionProfile {
 }
 
 export interface AulaProfile {
-  id: number;
-  name: string;
+  /** Aula names this `profileId`, not `id`. */
+  profileId: number;
+  /** Aula names this `displayName`, not `name`. */
+  displayName: string;
+  portalRole?: string;
   children?: AulaProfileChild[];
   institutionProfiles?: AulaInstitutionProfile[];
 }

--- a/packages/mcp-server/src/discover.ts
+++ b/packages/mcp-server/src/discover.ts
@@ -144,7 +144,7 @@ export async function buildDiscoverManifest(context: AulaContext): Promise<Disco
   const now = Math.floor(Date.now() / 1000);
   const manifest: DiscoverManifest = {
     user: {
-      name: profilesData.profiles?.[0]?.name ?? record.username,
+      name: profilesData.profiles?.[0]?.displayName ?? record.username,
       username: record.username,
       ...(record.identityName ? { identityName: record.identityName } : {}),
     },


### PR DESCRIPTION
Two symptoms, and the first one has a cause worth naming.

### 1. `AulaProfile` had invented field names

The interface declared `id` and `name`. Aula returns `profileId` and `displayName`, so both were always `undefined`.

`aula whoami` showed it plainly:

```
• Profile: undefined (id undefined)
```

`discover.ts` hid it. It falls back to the username, so the MCP manifest an LLM reads reported:

```json
{"name":"jarllyng","username":"jarllyng","identityName":"Jarl Lyng Jakobsen"}
```

The CLI line is cosmetic. The manifest is not, since `user.name` is what a model uses when it addresses the user.

A fixture in `aula-client.test.ts` asserted on the invented names, which is why nothing looked wrong: the test agreed with the code rather than with Aula. It now uses the real shape, and that assertion is what caught the last consumer when the type was corrected.

### 2. `doctor` probed a widget the profile may not have

The token check was hardcoded to widget `0001` (EasyIQ). Aula answers 400 for a widget you were never granted, which is correct, so every school on another vendor saw a permanent red line:

```
[FAIL] aulaToken.getAulaToken (widget 0001 / EasyIQ)   API returned status 400
```

The check directly above already collects the profile's widget IDs. It now probes the first of those, and skips cleanly when there are none.

### Verified against a live account

School uses Meebook (widget 0004). After the change:

```
• Profile: Jarl Lyng Jakobsen (id 2335797)

[PASS] aulaToken.getAulaToken    widget 0138: token issued (819 chars)
✓ All 10 checks passed (Aula API v24).
```

and `aula.discover` reports `"name":"Jarl Lyng Jakobsen"`.

`pnpm typecheck`, `pnpm lint` and `bun test` are green (262 pass, 1 skip, 0 fail).
