### PR TITLE
feat(cli): add `aula notifications list-ids` for no-LLM Overblik pre-check

### DIFF
--- a/apps/cli/src/commands/notifications.test.ts
+++ b/apps/cli/src/commands/notifications.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { asArray, stableId } from './notifications.ts';
+
+describe('asArray — shape tolerance', () => {
+  test('top-level array', () => {
+    expect(asArray([{ a: 1 }, { a: 2 }])).toHaveLength(2);
+  });
+
+  test('{ data: [...] } (Aula default)', () => {
+    expect(asArray({ data: [{ a: 1 }], status: { code: 0 } })).toHaveLength(1);
+  });
+
+  test('{ data: { notifications: [...] } }', () => {
+    expect(asArray({ data: { notifications: [{ a: 1 }, { a: 2 }] } })).toHaveLength(2);
+  });
+
+  test('{ notifications: [...] }', () => {
+    expect(asArray({ notifications: [{ a: 1 }] })).toHaveLength(1);
+  });
+
+  test('unexpected shapes degrade to empty', () => {
+    expect(asArray(null)).toEqual([]);
+    expect(asArray({})).toEqual([]);
+    expect(asArray('nope')).toEqual([]);
+    expect(asArray({ data: 'not-an-array' })).toEqual([]);
+  });
+});
+
+describe('stableId — dedup key', () => {
+  test('prefers notificationId string', () => {
+    expect(stableId({ notificationId: 'abc-123', triggered: 't1' })).toBe('abc-123');
+  });
+
+  test('falls back to id', () => {
+    expect(stableId({ id: 'xyz' })).toBe('xyz');
+    expect(stableId({ id: 42 })).toBe('42');
+  });
+
+  test('hashes the record when no identifier present', () => {
+    const id = stableId({ notificationArea: 'Posts', triggered: 't1' });
+    expect(id).toMatch(/^sha:[0-9a-f]{16}$/);
+  });
+
+  test('hash is stable across key order', () => {
+    expect(stableId({ a: 1, b: 2 })).toBe(stableId({ b: 2, a: 1 }));
+  });
+
+  test('hash differs for different records', () => {
+    expect(stableId({ notificationArea: 'Posts', triggered: 't1' })).not.toBe(
+      stableId({ notificationArea: 'Posts', triggered: 't2' }),
+    );
+  });
+});

--- a/apps/cli/src/commands/notifications.ts
+++ b/apps/cli/src/commands/notifications.ts
@@ -1,0 +1,102 @@
+/**
+ * `aula notifications list-ids` — print a stable id (plus best-effort
+ * type/triggered) per notification in the active guardian's feed, as
+ * JSON. Cheap pre-check for polling scripts: diff against a state-file
+ * `seenNotificationIds` list and only fire downstream classification
+ * when something is genuinely new.
+ *
+ * Same rationale as `threads list-ids` (see threads.ts): openclaw's
+ * `/tools/invoke` HTTP surface doesn't expose MCP-plugin-server tools,
+ * so a shell poller can't reach `aula.notifications.list` from outside
+ * the LLM path. This CLI command sidesteps that, keeping the
+ * "anything new?" check off the LLM bill.
+ *
+ * Aula's `notifications.getNotificationsForActiveProfile` is untyped
+ * (the client returns raw JSON), so we stay shape-tolerant: locate the
+ * array wherever it lives, prefer a `notificationId`/`id` string as the
+ * dedup key, and fall back to a stable hash of the record so dedup
+ * still works if the shape drifts. `type`/`triggered` are surfaced
+ * best-effort for debugging only — the poller dedups on `id` alone and
+ * the LLM does the semantic (Overblik-vs-message) filtering on the full
+ * payload it fetches via the MCP tool.
+ */
+
+import { createHash } from 'node:crypto';
+import { AulaHttpClient, withFreshTokens } from '@aula-mcp/aula-auth';
+import { AulaClient } from '@aula-mcp/aula-client';
+import { fail, fmt, printJson } from '../io.ts';
+import { defaultStore } from '../store.ts';
+
+/** Find the notifications array regardless of where Aula nests it. */
+export function asArray(raw: unknown): Record<string, unknown>[] {
+  const pick = (v: unknown): unknown[] | null => (Array.isArray(v) ? v : null);
+  if (Array.isArray(raw)) return raw as Record<string, unknown>[];
+  const obj = (raw ?? {}) as Record<string, unknown>;
+  const data = (obj.data ?? {}) as Record<string, unknown>;
+  const found = pick(obj.data) ?? pick(data.notifications) ?? pick(obj.notifications) ?? [];
+  return found as Record<string, unknown>[];
+}
+
+/**
+ * Stable per-notification id for dedup. Prefer Aula's own identifier;
+ * if absent, hash a canonical (sorted-key) serialization of the record
+ * so the id is reproducible across polls.
+ */
+export function stableId(n: Record<string, unknown>): string {
+  const direct = n.notificationId ?? n.id;
+  if (typeof direct === 'string' && direct.length > 0) return direct;
+  if (typeof direct === 'number') return String(direct);
+  const canonical = JSON.stringify(
+    Object.keys(n)
+      .sort()
+      .map((k) => [k, n[k]]),
+  );
+  return `sha:${createHash('sha256').update(canonical).digest('hex').slice(0, 16)}`;
+}
+
+function firstString(n: Record<string, unknown>, keys: string[]): string | null {
+  for (const k of keys) {
+    if (typeof n[k] === 'string') return n[k] as string;
+  }
+  return null;
+}
+
+export async function runNotificationsListIds(): Promise<void> {
+  const store = defaultStore();
+  const http = new AulaHttpClient();
+  let record: Awaited<ReturnType<typeof withFreshTokens>>;
+  try {
+    record = await withFreshTokens({ store, http });
+  } catch (e) {
+    printJson({
+      ok: false,
+      error: 'tokens',
+      message: (e as Error).message,
+      hint: `Run ${fmt.bold('aula login')} or ${fmt.bold('aula refresh-stepup')} to recover.`,
+    });
+    process.exit(1);
+  }
+
+  const client = new AulaClient({ tokens: record.tokens, http });
+  try {
+    // Prime the guardian profile: `*ForActiveProfile` endpoints 403 if
+    // it hasn't been activated — same preflight threads list-ids does,
+    // and what the MCP notifications tool gets via getGuardianUserId().
+    await client.getProfileContext('guardian');
+    const raw = await client.getNotifications();
+    const notifications = asArray(raw).map((n) => ({
+      id: stableId(n),
+      type: firstString(n, ['notificationArea', 'notificationType', 'type']),
+      triggered: firstString(n, ['triggered', 'triggeredTime', 'eventTime']),
+    }));
+    printJson({ ok: true, notifications });
+  } catch (e) {
+    printJson({
+      ok: false,
+      error: 'api',
+      message: (e as Error).message,
+    });
+    fail((e as Error).message);
+    process.exit(1);
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -20,6 +20,7 @@ import { runDoctor } from './commands/doctor.ts';
 import { runLog } from './commands/log.ts';
 import { runLogin } from './commands/login.ts';
 import { runLogout } from './commands/logout.ts';
+import { runNotificationsListIds } from './commands/notifications.ts';
 import { runRefreshStepup } from './commands/refresh-stepup.ts';
 import { runStatus } from './commands/status.ts';
 import { runThreadFetch, runThreadsListIds } from './commands/threads.ts';
@@ -43,6 +44,7 @@ ${fmt.bold('Usage')}:
   aula tokens export <dir>
   aula tokens import <dir>
   aula threads list-ids [--page-size N] [--json]
+  aula notifications list-ids [--json]
   aula ugeplan fetch --child-ids <csv> --institution-codes <csv> [--iso-weeks <csv>]
   aula thread fetch <id> [--page N]
   aula transcript list [--json]
@@ -156,6 +158,19 @@ async function main(): Promise<void> {
         default:
           process.stderr.write(`Unknown threads subcommand: ${sub ?? '<missing>'}\n`);
           process.stderr.write('Try: aula threads list-ids [--page-size N]\n');
+          process.exit(2);
+      }
+      break;
+    }
+    case 'notifications': {
+      const sub = args.positional[0];
+      switch (sub) {
+        case 'list-ids':
+          await runNotificationsListIds();
+          break;
+        default:
+          process.stderr.write(`Unknown notifications subcommand: ${sub ?? '<missing>'}\n`);
+          process.stderr.write('Try: aula notifications list-ids\n');
           process.exit(2);
       }
       break;


### PR DESCRIPTION
Adds `aula notifications list-ids` — a cheap, no-LLM-bill pre-check of the active guardian's notification feed, i.e. the feed behind Aula's "Overblik" front page (Opslag posts, calendar events, gallery, institution notices).

### Why

Same rationale as the existing `threads list-ids` (#24) and `ugeplan fetch` (#40): a shell poller wants to answer *"is there anything new?"* before paying for a model turn, and an MCP host's tool-invoke HTTP surface generally doesn't expose plugin-server tools — so `aula.notifications.list` is unreachable from outside the LLM path. A dedicated subcommand closes that gap and completes the set: messages, week plan, and now the notification feed all have an off-LLM change-detection path.

Concretely, my poller diffs the returned ids against a state-file `seenNotificationIds` and only fires classification when something is genuinely new. Notifications are the highest-volume feed of the three, so this is where the pre-check saves the most.

### How

`notifications.getNotificationsForActiveProfile` returns untyped JSON, so the command stays shape-tolerant rather than pinning a schema that may drift:

- locates the notifications array wherever Aula nests it (`data`, `data.notifications`, `notifications`, or a bare array);
- prefers `notificationId` / `id` as the dedup key, and falls back to a stable SHA-256 of the record so dedup keeps working if the shape changes;
- surfaces `type` / `triggered` best-effort for debugging only — a caller should dedup on `id` alone.

Output mirrors the other `list-ids` commands:

```json
{ "ok": true, "notifications": [ { "id": "...", "type": "...", "triggered": "..." } ] }
```

### Tests

New unit tests cover both key paths (id present, and the hash fallback). `bun test`, `tsc --noEmit` and `biome check` are clean on this branch — the only failures in `bun test` are the pre-existing macOS Keychain roundtrip tests, which fail identically on a pristine `v1.4.0` checkout in my environment.

Branch is a single commit rebased onto `v1.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
