### PR TITLE
fix: support multiple streamable HTTP MCP sessions

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -27,10 +27,14 @@
  *   AULA_MCP_ALLOW_REMOTE=1   — allow binding to non-loopback addresses (refuses
  *                               by default; the server is single-user and any
  *                               peer with /mcp access can drive your tokens)
- *   AULA_MCP_SSE_MAX_SESSIONS — max concurrent legacy /sse sessions before new
- *                               GET /sse requests get 503'd (default 16)
- *   AULA_MCP_SSE_IDLE_MS      — evict /sse sessions idle for >this many ms
- *                               (default 300_000 = 5 min)
+ *   AULA_MCP_SSE_MAX_SESSIONS  — max concurrent legacy /sse sessions before new
+ *                                GET /sse requests get 503'd (default 16)
+ *   AULA_MCP_SSE_IDLE_MS       — evict /sse sessions idle for >this many ms
+ *                                (default 300_000 = 5 min)
+ *   AULA_MCP_HTTP_MAX_SESSIONS — max concurrent /mcp sessions before new
+ *                                initialize requests get 503'd (default 16)
+ *   AULA_MCP_HTTP_IDLE_MS      — evict /mcp sessions idle for >this many ms
+ *                                (default 300_000 = 5 min)
  *   AULA_MCP_INGRESS_PORT     — if set, also boots the in-addon setup/login UI
  *                               on this port (bound to 0.0.0.0 for HA Ingress).
  *                               Default unset; the HA addon sets it to 8099.
@@ -69,12 +73,61 @@ assertSafeBindAddress(HOST);
 // Keep each session's McpApp as well as its transport because McpServer.connect()
 // binds a server instance to a single transport.
 
+//
+// The session map is capped + idle-evicted, for the same reason the legacy
+// /sse map is: a client that goes away without sending DELETE /mcp (crash,
+// dropped network, a browser tab closed mid-session) leaves its McpApp and
+// transport behind forever. onsessionclosed only fires on an orderly close.
 interface StreamableHttpSession {
   transport: WebStandardStreamableHTTPServerTransport;
   app: McpApp;
+  lastActivityAt: number;
 }
 
+const HTTP_MAX_SESSIONS = Math.max(1, Number(process.env.AULA_MCP_HTTP_MAX_SESSIONS ?? 16));
+const HTTP_IDLE_MS = Math.max(1_000, Number(process.env.AULA_MCP_HTTP_IDLE_MS ?? 300_000));
+const HTTP_SWEEP_INTERVAL_MS = Math.max(1_000, Math.floor(HTTP_IDLE_MS / 4));
 const streamableHttpSessions = new Map<string, StreamableHttpSession>();
+
+async function closeHttpSession(sessionId: string, reason: string): Promise<void> {
+  const session = streamableHttpSessions.get(sessionId);
+  if (!session) return;
+  streamableHttpSessions.delete(sessionId);
+  try {
+    await session.transport.close();
+  } catch (err) {
+    logger.error('aula-mcp.http.transport_close_error', {
+      sessionId,
+      reason,
+      error: (err as Error).message,
+    });
+  }
+  try {
+    await session.app.mcp.close();
+  } catch (err) {
+    logger.error('aula-mcp.http.mcp_close_error', {
+      sessionId,
+      reason,
+      error: (err as Error).message,
+    });
+  }
+}
+
+// Single sweeper, started once at boot. `unref()` so the interval doesn't keep
+// the process alive on its own — shutdown clears it explicitly anyway.
+const httpSweeper: ReturnType<typeof setInterval> = setInterval(() => {
+  const now = Date.now();
+  for (const [sessionId, session] of streamableHttpSessions) {
+    if (now - session.lastActivityAt > HTTP_IDLE_MS) {
+      logger.info('aula-mcp.http.session_evicted_idle', {
+        sessionId,
+        idleMs: now - session.lastActivityAt,
+      });
+      void closeHttpSession(sessionId, 'idle');
+    }
+  }
+}, HTTP_SWEEP_INTERVAL_MS);
+httpSweeper.unref?.();
 
 const app = new Hono();
 
@@ -101,6 +154,7 @@ async function handleMcp(request: Request): Promise<Response> {
       );
     }
 
+    session.lastActivityAt = Date.now();
     return session.transport.handleRequest(request);
   }
 
@@ -108,6 +162,24 @@ async function handleMcp(request: Request): Promise<Response> {
   //
   // We create a fresh McpApp + transport here. The transport itself validates
   // that the request is a valid MCP initialization request.
+  if (streamableHttpSessions.size >= HTTP_MAX_SESSIONS) {
+    logger.warn('aula-mcp.http.session_rejected_cap', {
+      active: streamableHttpSessions.size,
+      cap: HTTP_MAX_SESSIONS,
+    });
+    return Response.json(
+      {
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: `Too many active MCP sessions (cap ${HTTP_MAX_SESSIONS}). Retry shortly.`,
+        },
+        id: null,
+      },
+      { status: 503 },
+    );
+  }
+
   let createdSessionId: string | undefined;
 
   const sessionApp = createMcpApp({ logger });
@@ -122,6 +194,7 @@ async function handleMcp(request: Request): Promise<Response> {
       streamableHttpSessions.set(newSessionId, {
         transport,
         app: sessionApp,
+        lastActivityAt: Date.now(),
       });
 
       logger.info('aula-mcp.http.session_initialized', {
@@ -184,7 +257,6 @@ async function handleMcp(request: Request): Promise<Response> {
 app.post('/mcp', (c) => handleMcp(c.req.raw));
 app.get('/mcp', (c) => handleMcp(c.req.raw));
 app.delete('/mcp', (c) => handleMcp(c.req.raw));
-
 
 // Legacy MCP SSE transport — for clients that haven't moved to Streamable HTTP
 // yet, notably Home Assistant's official `mcp` (client) integration. Each
@@ -378,53 +450,18 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   if (shuttingDown) return;
   shuttingDown = true;
   process.stdout.write(`\n${signal} received — shutting down gracefully…\n`);
-  // Stop the idle sweeper first so it can't fire mid-shutdown and race with
+  // Stop the idle sweepers first so they can't fire mid-shutdown and race with
   // session cleanup; this also lets the event loop drain if anything still
-  // refs the interval.
+  // refs an interval.
   clearInterval(sseSweeper);
+  clearInterval(httpSweeper);
   try {
-    await Promise.all(
-      Array.from(sseSessions.keys()).map((sid) => closeSseSession(sid, 'shutdown')),
-    );
+    await Promise.all([
+      ...Array.from(sseSessions.keys()).map((sid) => closeSseSession(sid, 'shutdown')),
+      ...Array.from(streamableHttpSessions.keys()).map((sid) => closeHttpSession(sid, 'shutdown')),
+    ]);
     await server.stop();
     if (setupServer) await setupServer.stop();
-    try {
-  await Promise.all(
-    Array.from(sseSessions.keys()).map((sid) => closeSseSession(sid, 'shutdown')),
-  );
-
-  await server.stop();
-
-  if (setupServer) await setupServer.stop();
-
-  await Promise.all(
-    Array.from(streamableHttpSessions.entries()).map(async ([sessionId, session]) => {
-      streamableHttpSessions.delete(sessionId);
-
-      try {
-        await session.transport.close();
-      } catch (err) {
-        logger.error('aula-mcp.http.transport_close_error', {
-          sessionId,
-          error: (err as Error).message,
-        });
-      }
-
-      try {
-        await session.app.mcp.close();
-      } catch (err) {
-        logger.error('aula-mcp.http.mcp_close_error', {
-          sessionId,
-          error: (err as Error).message,
-        });
-      }
-    }),
-  );
-} catch (err) {
-  logger.error('aula-mcp.shutdown_error', {
-    error: (err as Error).message,
-  });
-}
   } catch (err) {
     logger.error('aula-mcp.shutdown_error', { error: (err as Error).message });
   }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -51,29 +51,140 @@ const logger = process.env.AULA_MCP_LOG === '1' ? consoleLogger('aula-mcp') : si
 
 assertSafeBindAddress(HOST);
 
-const { mcp } = createMcpApp({ logger });
+// Streamable HTTP transport.
+//
+// One transport instance represents one MCP session. A client starts a new
+// session by POSTing an `initialize` request without an Mcp-Session-Id header.
+// The transport then generates a session ID and returns it to the client.
+//
+// Subsequent requests from that client include Mcp-Session-Id, which we use to
+// route the request back to the transport that owns that session.
+//
+// Previously aula-mcp created one global transport and reused it for every
+// client. That meant the first client could initialize successfully, but a
+// later client/reconnect would hit the same initialized transport and receive:
+//
+//   Invalid Request: Server already initialized
+//
+// Keep each session's McpApp as well as its transport because McpServer.connect()
+// binds a server instance to a single transport.
 
-// Streamable HTTP transport. Stateful mode — the SDK explicitly forbids
-// reusing a *stateless* transport across requests
-// ("Stateless transport cannot be reused across requests"), so we provide a
-// session-id generator and let the transport track per-session state. For
-// single-user use this is a single session that gets created on the first
-// request and reused thereafter.
-const transport = new WebStandardStreamableHTTPServerTransport({
-  enableJsonResponse: true,
-  sessionIdGenerator: () => crypto.randomUUID(),
-});
+interface StreamableHttpSession {
+  transport: WebStandardStreamableHTTPServerTransport;
+  app: McpApp;
+}
 
-await mcp.connect(transport);
+const streamableHttpSessions = new Map<string, StreamableHttpSession>();
 
 const app = new Hono();
 
 app.get('/healthz', (c) => c.json({ ok: true, name: 'aula-mcp' }));
 
-const handleMcp = async (request: Request): Promise<Response> => transport.handleRequest(request);
+async function handleMcp(request: Request): Promise<Response> {
+  const sessionId = request.headers.get('mcp-session-id');
+
+  // Existing MCP session: route back to the transport that owns it.
+  if (sessionId) {
+    const session = streamableHttpSessions.get(sessionId);
+
+    if (!session) {
+      return Response.json(
+        {
+          jsonrpc: '2.0',
+          error: {
+            code: -32001,
+            message: 'Session not found',
+          },
+          id: null,
+        },
+        { status: 404 },
+      );
+    }
+
+    return session.transport.handleRequest(request);
+  }
+
+  // A request without a session ID can only start a new session.
+  //
+  // We create a fresh McpApp + transport here. The transport itself validates
+  // that the request is a valid MCP initialization request.
+  let createdSessionId: string | undefined;
+
+  const sessionApp = createMcpApp({ logger });
+
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    enableJsonResponse: true,
+    sessionIdGenerator: () => crypto.randomUUID(),
+
+    onsessioninitialized: (newSessionId) => {
+      createdSessionId = newSessionId;
+
+      streamableHttpSessions.set(newSessionId, {
+        transport,
+        app: sessionApp,
+      });
+
+      logger.info('aula-mcp.http.session_initialized', {
+        sessionId: newSessionId,
+      });
+    },
+
+    onsessionclosed: (closedSessionId) => {
+      streamableHttpSessions.delete(closedSessionId);
+
+      logger.info('aula-mcp.http.session_closed', {
+        sessionId: closedSessionId,
+      });
+    },
+  });
+
+  await sessionApp.mcp.connect(transport);
+
+  try {
+    const response = await transport.handleRequest(request);
+
+    // If initialization failed before a session ID was created, this transport
+    // is not stored anywhere and should be cleaned up immediately.
+    if (!createdSessionId) {
+      try {
+        await transport.close();
+      } catch {
+        // Best-effort cleanup only.
+      }
+
+      try {
+        await sessionApp.mcp.close();
+      } catch {
+        // Best-effort cleanup only.
+      }
+    }
+
+    return response;
+  } catch (err) {
+    // Initialization failed: make sure the temporary server/transport does not
+    // leak resources.
+    if (!createdSessionId) {
+      try {
+        await transport.close();
+      } catch {
+        // Best-effort cleanup only.
+      }
+
+      try {
+        await sessionApp.mcp.close();
+      } catch {
+        // Best-effort cleanup only.
+      }
+    }
+
+    throw err;
+  }
+}
+
 app.post('/mcp', (c) => handleMcp(c.req.raw));
 app.get('/mcp', (c) => handleMcp(c.req.raw));
 app.delete('/mcp', (c) => handleMcp(c.req.raw));
+
 
 // Legacy MCP SSE transport — for clients that haven't moved to Streamable HTTP
 // yet, notably Home Assistant's official `mcp` (client) integration. Each
@@ -277,7 +388,43 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
     );
     await server.stop();
     if (setupServer) await setupServer.stop();
-    await mcp.close();
+    try {
+  await Promise.all(
+    Array.from(sseSessions.keys()).map((sid) => closeSseSession(sid, 'shutdown')),
+  );
+
+  await server.stop();
+
+  if (setupServer) await setupServer.stop();
+
+  await Promise.all(
+    Array.from(streamableHttpSessions.entries()).map(async ([sessionId, session]) => {
+      streamableHttpSessions.delete(sessionId);
+
+      try {
+        await session.transport.close();
+      } catch (err) {
+        logger.error('aula-mcp.http.transport_close_error', {
+          sessionId,
+          error: (err as Error).message,
+        });
+      }
+
+      try {
+        await session.app.mcp.close();
+      } catch (err) {
+        logger.error('aula-mcp.http.mcp_close_error', {
+          sessionId,
+          error: (err as Error).message,
+        });
+      }
+    }),
+  );
+} catch (err) {
+  logger.error('aula-mcp.shutdown_error', {
+    error: (err as Error).message,
+  });
+}
   } catch (err) {
     logger.error('aula-mcp.shutdown_error', { error: (err as Error).message });
   }


### PR DESCRIPTION
Summary

Fixes the Streamable HTTP MCP server so that each MCP session gets its own WebStandardStreamableHTTPServerTransport and McpApp instance.

Previously, server.ts created a single global Streamable HTTP transport and reused it for all /mcp requests. After the first client initialized that transport, subsequent MCP initialization attempts could fail with:
Invalid Request: Server already initialized
I ran into this when connecting aula-mcp to Open WebUI using its native Streamable HTTP MCP integration. Open WebUI creates and closes MCP sessions as needed, including between prompts, so the global transport could only serve the first session successfully.

What changed

The Streamable HTTP implementation now:

* creates a fresh McpApp and WebStandardStreamableHTTPServerTransport for each new MCP session
* stores active sessions by Mcp-Session-Id
* routes subsequent requests to the correct transport
* removes sessions when they are closed
* cleans up transports and MCP server instances during shutdown
* cleans up temporary transports when initialization fails

This follows the same general per-session architecture already used by the legacy SSE implementation in server.ts.

Testing

Tested locally with:

* aula-mcp running as a systemd service on Ubuntu
* Open WebUI using native MCP Streamable HTTP
* repeated MCP connections without restarting aula-mcp
* multiple prompts causing Open WebUI to close and create new MCP sessions

Before the change, the first MCP interaction could succeed but subsequent connections failed with Server already initialized.

After the change, multiple sessions initialize and close successfully without restarting aula-mcp. With AULA_MCP_LOG=1, I can see independent session lifecycle events such as:

aula-mcp.http.session_initialized
aula-mcp.http.session_closed

across successive Open WebUI prompts, without the previous initialization error.
I also ran 
pnpm exec tsc -p tsconfig.json --noEmit
with no typescript errors.
Scope

This PR only addresses MCP Streamable HTTP session lifecycle/transport handling. Any model-specific tool selection or function-calling behavior in Open WebUI is separate from this fix.

Background

I originally encountered this while trying to use aula-mcp from a local LLM/Open WebUI setup. The failure was reproducible because Open WebUI does not necessarily keep one MCP session alive for the entire chat; it may initialize and close sessions between tool-use cycles.

The existing global transport therefore behaved like a single-use MCP session rather than a server capable of serving multiple sequential clients.