### PR TITLE
feat(mcp): add aula.messages.mark_read, and surface thread pagination

### DIFF
--- a/packages/aula-client/src/aula-client.test.ts
+++ b/packages/aula-client/src/aula-client.test.ts
@@ -207,6 +207,48 @@ describe('AulaClient.getMessagesForThread step-up', () => {
   });
 });
 
+describe('AulaClient.getThreadsPage', () => {
+  test("surfaces Aula's moreMessagesExist as hasMorePages", async () => {
+    const http = new FakeHttp();
+    http.enqueue(
+      // version probe: profiles.getProfilesByLogin at v22 OK
+      { status: 200, body: envelope({ profiles: [] }) },
+      {
+        status: 200,
+        body: envelope({ threads: [{ id: 1, read: false }], page: 0, moreMessagesExist: true }),
+      },
+    );
+    const c = makeClient(http);
+    const out = await c.getThreadsPage();
+    expect(out.threads).toHaveLength(1);
+    expect(out.page).toBe(0);
+    expect(out.hasMorePages).toBe(true);
+  });
+
+  test('treats a missing moreMessagesExist as the last page', async () => {
+    const http = new FakeHttp();
+    http.enqueue(
+      { status: 200, body: envelope({ profiles: [] }) },
+      { status: 200, body: envelope({ threads: [] }) },
+    );
+    const c = makeClient(http);
+    const out = await c.getThreadsPage({ page: 4 });
+    expect(out.hasMorePages).toBe(false);
+    // Aula echoes the page back; fall back to what we asked for when it does not.
+    expect(out.page).toBe(4);
+  });
+
+  test('getThreads still returns a bare array', async () => {
+    const http = new FakeHttp();
+    http.enqueue(
+      { status: 200, body: envelope({ profiles: [] }) },
+      { status: 200, body: envelope({ threads: [{ id: 1 }, { id: 2 }], moreMessagesExist: true }) },
+    );
+    const c = makeClient(http);
+    expect(await c.getThreads()).toHaveLength(2);
+  });
+});
+
 interface PostedTemplate {
   institutionProfileId: number;
   byDate: string;

--- a/packages/aula-client/src/aula-client.ts
+++ b/packages/aula-client/src/aula-client.ts
@@ -320,6 +320,28 @@ export class AulaClient {
    * @param params     Extra query-string params (access_token + method are added)
    * @param body       JSON body for POST requests; pass undefined for GET
    */
+  /**
+   * Mark a thread as read, up to and including `messageId`.
+   *
+   * Aula has no "mark as read" verb — it moves a per-thread read *marker*,
+   * which is why the thread object carries `lastReadMessageId` rather than a
+   * boolean. Passing the thread's newest message id is what the web client
+   * does when you open a thread, and it clears the unread badge.
+   *
+   * `messageId` is Aula's opaque string id (e.g. "6a3d2467304484.24549709"),
+   * not a number — it comes from `thread.latestMessage.id` on getThreads or
+   * from a message in getMessagesForThread.
+   *
+   * `commonInboxId` / `otpInboxId` select a shared or OTP mailbox; null means
+   * the guardian's personal inbox, which is the only one this client reads.
+   */
+  async setLastReadMessage(threadId: number, messageId: string): Promise<unknown> {
+    return this.postJson<unknown>(
+      'messaging.setLastReadMessage',
+      JSON.stringify({ threadId, messageId, commonInboxId: null, otpInboxId: null }),
+    );
+  }
+
   async rawRequest(
     method: string,
     params: Record<string, string> = {},

--- a/packages/aula-client/src/aula-client.ts
+++ b/packages/aula-client/src/aula-client.ts
@@ -30,6 +30,7 @@ import type {
   ThreadMessage,
   ThreadMessagesData,
   ThreadsData,
+  ThreadsPage,
   UpdatePresenceTemplateArgs,
 } from './aula-types.ts';
 import { PRESENCE_ACTIVITY_TYPE, type PresenceStatusCode } from './aula-types.ts';
@@ -226,7 +227,15 @@ export class AulaClient {
     );
   }
 
-  async getThreads(opts: { page?: number; pageSize?: number } = {}): Promise<MessageThread[]> {
+  /**
+   * One page of threads, keeping Aula's `moreMessagesExist` flag.
+   *
+   * Aula serves 20 threads per page and ignores `pageSize` — asking for 50
+   * still returns 20. Without the flag a caller cannot tell a short page from
+   * the end of the mailbox, so `getThreads` below (which drops it) is only
+   * safe when you genuinely want the newest 20.
+   */
+  async getThreadsPage(opts: { page?: number; pageSize?: number } = {}): Promise<ThreadsPage> {
     const params: Record<string, string> = {
       sortOn: 'date',
       orderDirection: 'desc',
@@ -234,7 +243,16 @@ export class AulaClient {
     };
     if (opts.pageSize) params.pageSize = String(opts.pageSize);
     const data = await this.getJson<ThreadsData>('messaging.getThreads', params);
-    return data.threads ?? [];
+    return {
+      threads: data?.threads ?? [],
+      page: data?.page ?? opts.page ?? 0,
+      hasMorePages: data?.moreMessagesExist ?? false,
+    };
+  }
+
+  /** Threads only, discarding the pagination signal. See getThreadsPage. */
+  async getThreads(opts: { page?: number; pageSize?: number } = {}): Promise<MessageThread[]> {
+    return (await this.getThreadsPage(opts)).threads;
   }
 
   /**

--- a/packages/aula-client/src/aula-types.ts
+++ b/packages/aula-client/src/aula-types.ts
@@ -314,6 +314,26 @@ export interface MessageThread {
 
 export interface ThreadsData {
   threads: MessageThread[];
+  /** Echo of the requested page. */
+  page?: number;
+  /** True when further pages exist. Aula's own name for it — see ThreadsPage
+   *  for the shape callers should prefer. */
+  moreMessagesExist?: boolean;
+}
+
+/**
+ * One page of threads, with the pagination signal kept.
+ *
+ * Aula serves threads 20 at a time and **ignores `pageSize` entirely** — ask
+ * for 50 and you still get 20. A caller that reads page 0 and stops therefore
+ * sees a fraction of the mailbox while believing it has seen all of it, which
+ * is a silent wrong answer rather than an error. Keep requesting pages while
+ * `hasMorePages` is true.
+ */
+export interface ThreadsPage {
+  threads: MessageThread[];
+  page: number;
+  hasMorePages: boolean;
 }
 
 /** One file attached to a thread message. Aula wraps each entry in a `file`

--- a/packages/aula-client/src/index.ts
+++ b/packages/aula-client/src/index.ts
@@ -31,6 +31,7 @@ export {
   type ThreadMessageAttachment,
   type ThreadMessagesData,
   type ThreadsData,
+  type ThreadsPage,
   type UpdatePresenceTemplateArgs,
 } from './aula-types.ts';
 export {

--- a/packages/mcp-server/src/discover.test.ts
+++ b/packages/mcp-server/src/discover.test.ts
@@ -176,6 +176,26 @@ describe('buildDiscoverManifest', () => {
     }
   });
 
+  test('messages capability surfaces mark_read only when writes are enabled', async () => {
+    const original = process.env.AULA_MCP_WRITE;
+    try {
+      delete process.env.AULA_MCP_WRITE;
+      const off = await buildDiscoverManifest(fakeContext());
+      expect(off.capabilities.messages?.tools).not.toContain('aula.messages.mark_read');
+      expect(off.capabilities.messages?.notes).toContain('AULA_MCP_WRITE=1');
+
+      process.env.AULA_MCP_WRITE = '1';
+      const on = await buildDiscoverManifest(fakeContext());
+      expect(on.capabilities.messages?.tools).toContain('aula.messages.mark_read');
+      // With writes on the note stops explaining the gate and starts warning
+      // about the one thing that cannot be undone.
+      expect(on.capabilities.messages?.notes).toContain('irreversible');
+    } finally {
+      if (original === undefined) delete process.env.AULA_MCP_WRITE;
+      else process.env.AULA_MCP_WRITE = original;
+    }
+  });
+
   test('omits identityName when not set in record', async () => {
     const m = await buildDiscoverManifest(fakeContext({ identityName: null }));
     expect(m.user.identityName).toBeUndefined();

--- a/packages/mcp-server/src/discover.ts
+++ b/packages/mcp-server/src/discover.ts
@@ -249,8 +249,24 @@ function buildCapabilities(
       tools: ['aula.calendar.events'],
     },
     messages: {
-      summary: 'Aula messaging threads. Sensitive threads require MitID step-up.',
-      tools: ['aula.messages.list_threads', 'aula.messages.get_thread'],
+      summary: writeEnabled
+        ? 'Aula messaging threads, and marking a thread read. Sensitive threads ' +
+          'require MitID step-up.'
+        : 'Aula messaging threads. Sensitive threads require MitID step-up.',
+      tools: writeEnabled
+        ? ['aula.messages.list_threads', 'aula.messages.get_thread', 'aula.messages.mark_read']
+        : ['aula.messages.list_threads', 'aula.messages.get_thread'],
+      ...(writeEnabled
+        ? {
+            notes:
+              'aula.messages.mark_read is irreversible — Aula offers no way to set a ' +
+              'thread back to unread. Only call it for threads the user has actually seen.',
+          }
+        : {
+            notes:
+              'aula.messages.mark_read (marking a thread read) is available only when ' +
+              'the server runs with AULA_MCP_WRITE=1.',
+          }),
     },
     notifications: {
       summary: 'Unread items + activity badge counts for the active guardian.',

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -60,14 +60,22 @@ describe('aula.messages.mark_read', () => {
     content: Array<{ type: 'text'; text: string }>;
   }>;
 
-  function register(threads: unknown[]): {
+  /** `pages` models Aula's 20-per-page paging: one array per page. */
+  function register(pages: unknown[][]): {
     markRead: (args: { threadId: number; messageId?: string }) => Promise<Record<string, unknown>>;
     calls: Array<[number, string]>;
+    pagesRequested: number[];
   } {
     const calls: Array<[number, string]> = [];
+    const pagesRequested: number[] = [];
     const fakeClient = {
-      async getThreads() {
-        return threads;
+      async getThreadsPage({ page = 0 }: { page?: number } = {}) {
+        pagesRequested.push(page);
+        return {
+          threads: pages[page] ?? [],
+          page,
+          hasMorePages: page + 1 < pages.length,
+        };
       },
       async setLastReadMessage(threadId: number, messageId: string) {
         calls.push([threadId, messageId]);
@@ -107,28 +115,56 @@ describe('aula.messages.mark_read', () => {
         return JSON.parse(first.text) as Record<string, unknown>;
       },
       calls,
+      pagesRequested,
     };
   }
 
   test('passes an explicit messageId straight through', async () => {
-    const { markRead, calls } = register([]);
+    const { markRead, calls, pagesRequested } = register([]);
     const out = await markRead({ threadId: 42, messageId: '6a3d24.99' });
     expect(calls).toEqual([[42, '6a3d24.99']]);
     expect(out.ok).toBe(true);
+    // An explicit id means no reason to go looking for the thread.
+    expect(pagesRequested).toEqual([]);
   });
 
   test('resolves messageId from the thread list when omitted', async () => {
     const { markRead, calls } = register([
-      { id: 7, latestMessage: { id: 'aaa.1' } },
-      { id: 42, latestMessage: { id: 'bbb.2' } },
+      [
+        { id: 7, latestMessage: { id: 'aaa.1' } },
+        { id: 42, latestMessage: { id: 'bbb.2' } },
+      ],
     ]);
     const out = await markRead({ threadId: 42 });
     expect(calls).toEqual([[42, 'bbb.2']]);
     expect(out.messageId).toBe('bbb.2');
   });
 
+  test('pages past the first 20 to find an older thread', async () => {
+    const { markRead, calls, pagesRequested } = register([
+      [{ id: 7, latestMessage: { id: 'aaa.1' } }],
+      [{ id: 8, latestMessage: { id: 'bbb.2' } }],
+      [{ id: 42, latestMessage: { id: 'ccc.3' } }],
+    ]);
+    const out = await markRead({ threadId: 42 });
+    expect(pagesRequested).toEqual([0, 1, 2]);
+    expect(calls).toEqual([[42, 'ccc.3']]);
+    expect(out.messageId).toBe('ccc.3');
+  });
+
+  test('stops paging when Aula says there are no more pages', async () => {
+    const { markRead, calls, pagesRequested } = register([
+      [{ id: 7, latestMessage: { id: 'aaa.1' } }],
+      [{ id: 8, latestMessage: { id: 'bbb.2' } }],
+    ]);
+    const out = await markRead({ threadId: 42 });
+    expect(pagesRequested).toEqual([0, 1]);
+    expect(calls).toEqual([]);
+    expect(out.error).toBe('message_id_unresolved');
+  });
+
   test('reports message_id_unresolved rather than writing a bogus marker', async () => {
-    const { markRead, calls } = register([{ id: 7, latestMessage: { id: 'aaa.1' } }]);
+    const { markRead, calls } = register([[{ id: 7, latestMessage: { id: 'aaa.1' } }]]);
     const out = await markRead({ threadId: 42 });
     expect(calls).toEqual([]);
     expect(out.error).toBe('message_id_unresolved');

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { validateSetTemplateArgs } from './tools.ts';
+import { registerTools, validateSetTemplateArgs } from './tools.ts';
 
 describe('validateSetTemplateArgs', () => {
   test('picked_up_by needs pickedUpBy', () => {
@@ -46,5 +46,109 @@ describe('validateSetTemplateArgs', () => {
   test('a one-off (repeat never / unset) does not need repeatUntil', () => {
     expect(validateSetTemplateArgs({ activityType: 'send_home', repeat: 'never' })).toEqual([]);
     expect(validateSetTemplateArgs({ activityType: 'send_home' })).toEqual([]);
+  });
+});
+
+/**
+ * aula.messages.mark_read is registered only when AULA_MCP_WRITE=1, and its
+ * interesting behaviour is resolving `messageId` when the caller omits it.
+ * Capture the handler off a stub McpServer rather than driving the whole
+ * transport — the registration shape is all we need.
+ */
+describe('aula.messages.mark_read', () => {
+  type ToolHandler = (args: { threadId: number; messageId?: string }) => Promise<{
+    content: Array<{ type: 'text'; text: string }>;
+  }>;
+
+  function register(threads: unknown[]): {
+    markRead: (args: { threadId: number; messageId?: string }) => Promise<Record<string, unknown>>;
+    calls: Array<[number, string]>;
+  } {
+    const calls: Array<[number, string]> = [];
+    const fakeClient = {
+      async getThreads() {
+        return threads;
+      },
+      async setLastReadMessage(threadId: number, messageId: string) {
+        calls.push([threadId, messageId]);
+        return { ok: true };
+      },
+    };
+    const context = {
+      async getClient() {
+        return fakeClient;
+      },
+      async getGuardianUserId() {
+        return '5000';
+      },
+    };
+    let handler: ToolHandler | undefined;
+    const server = {
+      registerTool(name: string, _config: unknown, fn: ToolHandler) {
+        if (name === 'aula.messages.mark_read') handler = fn;
+      },
+    };
+    const previous = process.env.AULA_MCP_WRITE;
+    process.env.AULA_MCP_WRITE = '1';
+    try {
+      // biome-ignore lint/suspicious/noExplicitAny: structural stubs for McpServer/AulaContext
+      registerTools(server as any, context as any);
+    } finally {
+      if (previous === undefined) delete process.env.AULA_MCP_WRITE;
+      else process.env.AULA_MCP_WRITE = previous;
+    }
+    if (!handler) throw new Error('aula.messages.mark_read was not registered');
+    const registered = handler;
+    return {
+      async markRead(args) {
+        const res = await registered(args);
+        const [first] = res.content;
+        if (!first) throw new Error('tool returned no content');
+        return JSON.parse(first.text) as Record<string, unknown>;
+      },
+      calls,
+    };
+  }
+
+  test('passes an explicit messageId straight through', async () => {
+    const { markRead, calls } = register([]);
+    const out = await markRead({ threadId: 42, messageId: '6a3d24.99' });
+    expect(calls).toEqual([[42, '6a3d24.99']]);
+    expect(out.ok).toBe(true);
+  });
+
+  test('resolves messageId from the thread list when omitted', async () => {
+    const { markRead, calls } = register([
+      { id: 7, latestMessage: { id: 'aaa.1' } },
+      { id: 42, latestMessage: { id: 'bbb.2' } },
+    ]);
+    const out = await markRead({ threadId: 42 });
+    expect(calls).toEqual([[42, 'bbb.2']]);
+    expect(out.messageId).toBe('bbb.2');
+  });
+
+  test('reports message_id_unresolved rather than writing a bogus marker', async () => {
+    const { markRead, calls } = register([{ id: 7, latestMessage: { id: 'aaa.1' } }]);
+    const out = await markRead({ threadId: 42 });
+    expect(calls).toEqual([]);
+    expect(out.error).toBe('message_id_unresolved');
+  });
+
+  test('is not registered without AULA_MCP_WRITE=1', () => {
+    let seen = false;
+    const server = {
+      registerTool(name: string) {
+        if (name === 'aula.messages.mark_read') seen = true;
+      },
+    };
+    const previous = process.env.AULA_MCP_WRITE;
+    delete process.env.AULA_MCP_WRITE;
+    try {
+      // biome-ignore lint/suspicious/noExplicitAny: structural stub for McpServer
+      registerTools(server as any, {} as any);
+    } finally {
+      if (previous !== undefined) process.env.AULA_MCP_WRITE = previous;
+    }
+    expect(seen).toBe(false);
   });
 });

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -426,19 +426,34 @@ export function registerTools(server: McpServer, context: AulaContext): void {
 
         let messageId = args.messageId;
         if (!messageId) {
-          const thread = (await client.getThreads({ pageSize: 100 })).find(
-            (t) => t.id === args.threadId,
-          );
-          const latest = thread?.latestMessage?.id;
-          if (latest == null) {
+          // Aula pages threads 20 at a time and ignores pageSize, so a single
+          // getThreads call only ever sees the newest 20 — walk pages until the
+          // thread turns up. Bounded: a caller that already has the thread in
+          // hand should pass messageId rather than make us search for it.
+          const MAX_PAGES = 10;
+          let latest: string | undefined;
+          let pagesRead = 0;
+          for (let page = 0; page < MAX_PAGES; page++) {
+            const { threads, hasMorePages } = await client.getThreadsPage({ page });
+            pagesRead = page + 1;
+            const found = threads.find((t) => t.id === args.threadId);
+            if (found?.latestMessage?.id != null) {
+              latest = String(found.latestMessage.id);
+              break;
+            }
+            if (!hasMorePages) break;
+          }
+          if (latest === undefined) {
             return jsonContent({
               error: 'message_id_unresolved',
               message:
-                `Thread ${args.threadId} was not found in the first 100 threads, or carries ` +
-                'no latestMessage.id. Pass messageId explicitly.',
+                `Thread ${args.threadId} was not found in the first ${pagesRead} pages ` +
+                `(~${pagesRead * 20} threads), or carries no latestMessage.id. Pass ` +
+                'messageId explicitly — aula.messages.list_threads returns it as ' +
+                'thread.latestMessage.id.',
             });
           }
-          messageId = String(latest);
+          messageId = latest;
         }
 
         const result = await client.setLastReadMessage(args.threadId, messageId);
@@ -562,10 +577,22 @@ export function registerTools(server: McpServer, context: AulaContext): void {
     'aula.messages.list_threads',
     {
       title: 'List Aula message threads',
-      description: 'Most recent first. Use `page` for pagination (0-indexed).',
+      description:
+        'One page of threads, most recent first. Aula serves 20 per page and IGNORES ' +
+        '`pageSize` — asking for 50 still returns 20. Returns `{ threads, page, ' +
+        'hasMorePages }`: when `hasMorePages` is true there are older threads you have ' +
+        'not seen, so keep calling with `page` + 1 before concluding anything about the ' +
+        'mailbox as a whole (e.g. "no unread messages"). A single call answers "what ' +
+        'arrived recently", never "what does the mailbox contain".',
       inputSchema: {
         page: z.number().int().min(0).default(0).optional(),
-        pageSize: z.number().int().min(1).max(100).optional(),
+        pageSize: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe('Sent through to Aula, which ignores it. Kept in case that changes.'),
       },
     },
     async (args) => {
@@ -573,11 +600,11 @@ export function registerTools(server: McpServer, context: AulaContext): void {
       // See aula.messages.get_thread below — messaging endpoints 403
       // until the guardian profile is activated server-side.
       await context.getGuardianUserId();
-      const threads = await client.getThreads({
+      const page = await client.getThreadsPage({
         ...(args.page !== undefined ? { page: args.page } : {}),
         ...(args.pageSize !== undefined ? { pageSize: args.pageSize } : {}),
       });
-      return jsonContent(threads);
+      return jsonContent(page);
     },
   );
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -384,6 +384,67 @@ export function registerTools(server: McpServer, context: AulaContext): void {
         return jsonContent({ ok: true, result });
       },
     );
+
+    // --- aula.messages.mark_read (gated, write) ----------------------------
+    //
+    // Lives here rather than next to the other aula.messages.* tools so every
+    // write stays behind the one AULA_MCP_WRITE gate. Aula has no "mark as
+    // read" verb; see AulaClient.setLastReadMessage for what actually happens.
+
+    server.registerTool(
+      'aula.messages.mark_read',
+      {
+        title: 'Mark a message thread as read',
+        description:
+          'Move the read marker in a thread to its newest message, clearing the unread ' +
+          'badge. WRITES to Aula — enabled when AULA_MCP_WRITE=1. Pass `messageId` from ' +
+          '`aula.messages.list_threads` (thread.latestMessage.id); omit it to mark the ' +
+          'thread read up to whatever its newest message is right now. Marking read is ' +
+          'not reversible through this API — Aula offers no way to set a thread back to ' +
+          'unread, so only call this for threads the user has actually seen.',
+        inputSchema: {
+          threadId: z
+            .number()
+            .int()
+            .positive()
+            .describe('Thread id from aula.messages.list_threads.'),
+          messageId: z
+            .string()
+            .min(1)
+            .optional()
+            .describe(
+              'Aula\'s opaque message id (e.g. "6a3d2467304484.24549709"), NOT a number. ' +
+                "Defaults to the thread's newest message.",
+            ),
+        },
+      },
+      async (args) => {
+        const client = await context.getClient();
+        // Messaging endpoints 403 until the guardian profile is activated
+        // server-side — same priming as aula.messages.get_thread.
+        await context.getGuardianUserId();
+
+        let messageId = args.messageId;
+        if (!messageId) {
+          const thread = (await client.getThreads({ pageSize: 100 })).find(
+            (t) => t.id === args.threadId,
+          );
+          const latest = thread?.latestMessage?.id;
+          if (latest == null) {
+            return jsonContent({
+              error: 'message_id_unresolved',
+              message:
+                `Thread ${args.threadId} was not found in the first 100 threads, or carries ` +
+                'no latestMessage.id. Pass messageId explicitly.',
+            });
+          }
+          messageId = String(latest);
+        }
+
+        const result = await client.setLastReadMessage(args.threadId, messageId);
+        return jsonContent({ ok: true, threadId: args.threadId, messageId, result });
+      },
+    );
   }
 
   // --- aula.calendar.events ------------------------------------------------


### PR DESCRIPTION
Two commits. The second one exists because the first one walked into the bug it fixes.

---

## 1. `aula.messages.mark_read`

Aula has no "mark as read" verb. It moves a per-thread read **marker**, which is why `MessageThread` carries `lastReadMessageId` rather than a boolean. The obvious names get you nowhere — `messaging.markThreadAsRead`, `messaging.setThreadRead`, `messaging.markThreadsAsRead` and `messaging.setThreadsRead` all return 404.

What the web client actually sends when you open a thread:

```
POST /api/v24/?method=messaging.setLastReadMessage
{"threadId":123456789,"messageId":"6a1b2c3d4e5f60.12345678",
 "commonInboxId":null,"otpInboxId":null}
```

Two things worth knowing:

- **`messageId` is an opaque string**, not a number. Passing a number fails silently — the request succeeds and the marker does not move.
- **Fetching a thread does not mark it read.** `messaging.getMessagesForThread` leaves `read: false`; only the call above moves the marker. Verified by reading 18 threads, re-listing, and finding all 18 still unread.

`commonInboxId` / `otpInboxId` select a shared or OTP mailbox. `null` is the guardian's personal inbox, the only one this client reads.

`messageId` is optional — omitted, the tool resolves it from the thread list. Gated behind `AULA_MCP_WRITE=1` alongside `presence.set_template` and `presence.report_sick`. The description warns that this is one-way: Aula exposes no way to set a thread back to unread. Primes via `getGuardianUserId()` first, same as `aula.messages.get_thread`, or messaging 403s.

## 2. Pagination was invisible, and that made tools lie

`aula.messages.list_threads` returned a bare array. Aula serves **20 threads per page and ignores `pageSize`** — ask for 50, get 20. So a caller that read page 0 and stopped saw 20 of 638 threads while believing it had seen the mailbox.

That is not an error, it is a confidently wrong answer. An agent asked "do I have unread messages?" calls the tool once, gets 20 read threads, and reports "no unread messages" — authoritatively, with no indication it saw 3% of the inbox. In my case the real answer was 49 unread, sitting on pages the agent never requested.

Aula already reports the fix: `moreMessagesExist` and `page` come back alongside `threads`, and `getThreads` discarded both.

- `getThreadsPage()` returns `{ threads, page, hasMorePages }`.
- `getThreads()` is rebuilt on top of it and still returns a bare array, so `doctor.ts` and `threads.ts` are untouched — the change is additive.
- `list_threads` returns the page object, and its description now says a single call answers "what arrived recently", never "what does the mailbox contain".

`pageSize` is kept and still passed through in case Aula starts honouring it, but is documented as ignored rather than left looking functional.

**This also fixes commit 1.** `mark_read` resolved a missing `messageId` via `getThreads({ pageSize: 100 })` — the same trap, capped at 20 — and its error message claimed "not found in the first 100 threads" about threads it had never seen. It now walks pages until the thread appears, bounded at 10, and the message names the pages actually searched.

## Tests

Nine new cases. For `mark_read`: explicit `messageId` passes through untouched and skips the lookup entirely, an omitted one is resolved, it pages past the first 20 to find an older thread, it stops when `hasMorePages` goes false, an unknown thread reports `message_id_unresolved` without writing, and the tool is absent without `AULA_MCP_WRITE=1`. For the client: `moreMessagesExist` maps to `hasMorePages`, a missing flag means last page, and `getThreads` still returns an array.

`pnpm typecheck && pnpm lint && bun test` green — 280 pass, 0 fail.

Exercised against live Aula throughout: paging reports `hasMorePages: true` through page 30, `false` at page 31 (18 threads) and beyond; `mark_read` with `messageId` omitted found a thread from August 2025 on page 6 and moved its marker; an unknown thread id returned `message_id_unresolved` without issuing a write. 49 genuinely unread threads were cleared this way, and Aula's unread badge went to zero.

## Notes for review

- The method name was read off the wire in browser devtools, not from documentation — I have no Aula API reference. Stable on `v24` as of today, but it is an empirical finding and worth treating as one.
- Tested against one municipality, one guardian account, personal inbox only. `commonInboxId` / `otpInboxId` are passed as `null` unconditionally; shared mailboxes are untested.
- The 10-page bound in `mark_read` is a judgement call — ~200 threads deep. A caller that already holds the thread should pass `messageId` and skip the search.

