### PR TITLE
fix(cli): keep JSON-only command output parseable on failure

### DIFF
--- a/apps/cli/src/commands/notifications.ts
+++ b/apps/cli/src/commands/notifications.ts
@@ -24,7 +24,7 @@
 import { createHash } from 'node:crypto';
 import { AulaHttpClient, withFreshTokens } from '@aula-mcp/aula-auth';
 import { AulaClient } from '@aula-mcp/aula-client';
-import { fail, fmt, printJson } from '../io.ts';
+import { fmt, printJson } from '../io.ts';
 import { defaultStore } from '../store.ts';
 
 /** Find the notifications array regardless of where Aula nests it. */
@@ -96,7 +96,11 @@ export async function runNotificationsListIds(): Promise<void> {
       error: 'api',
       message: (e as Error).message,
     });
-    fail((e as Error).message);
+    // Deliberately no `fail()` here. This command's entire contract is one
+    // JSON document on stdout, and `fail` writes to stdout too — a trailing
+    // `✗ message` line makes the output unparseable for the very pollers
+    // this command exists to serve. The payload above already carries the
+    // message, and the non-zero exit code signals the failure.
     process.exit(1);
   }
 }

--- a/apps/cli/src/commands/threads.ts
+++ b/apps/cli/src/commands/threads.ts
@@ -22,7 +22,7 @@
 
 import { AulaHttpClient, withFreshTokens } from '@aula-mcp/aula-auth';
 import { AulaClient } from '@aula-mcp/aula-client';
-import { fail, fmt, printJson } from '../io.ts';
+import { fmt, printJson } from '../io.ts';
 import { defaultStore } from '../store.ts';
 
 export interface ThreadsListIdsCommandArgs {
@@ -74,7 +74,11 @@ export async function runThreadsListIds(args: ThreadsListIdsCommandArgs = {}): P
       error: 'api',
       message: (e as Error).message,
     });
-    fail((e as Error).message);
+    // Deliberately no `fail()` here. This command's entire contract is one
+    // JSON document on stdout, and `fail` writes to stdout too — a trailing
+    // `✗ message` line makes the output unparseable for the very pollers
+    // this command exists to serve. The payload above already carries the
+    // message, and the non-zero exit code signals the failure.
     process.exit(1);
   }
 }

--- a/apps/cli/src/commands/ugeplan.ts
+++ b/apps/cli/src/commands/ugeplan.ts
@@ -36,7 +36,7 @@ import {
   type NormalisedWeekPlanItem,
   WidgetTokenManager,
 } from '@aula-mcp/aula-client';
-import { fail, fmt, printJson } from '../io.ts';
+import { fmt, printJson } from '../io.ts';
 import { defaultStore } from '../store.ts';
 
 export interface UgeplanFetchCommandArgs {
@@ -151,7 +151,11 @@ export async function runUgeplanFetch(args: UgeplanFetchCommandArgs): Promise<vo
       error: 'api',
       message: (e as Error).message,
     });
-    fail((e as Error).message);
+    // Deliberately no `fail()` here. This command's entire contract is one
+    // JSON document on stdout, and `fail` writes to stdout too — a trailing
+    // `✗ message` line makes the output unparseable for the very pollers
+    // this command exists to serve. The payload above already carries the
+    // message, and the non-zero exit code signals the failure.
     process.exit(1);
   }
 }


### PR DESCRIPTION
## The problem

`fail()` writes to **stdout**, not stderr. So on an API error, the JSON-only commands emitted a valid JSON payload immediately followed by a `✗ message` line:

```json
{"ok":false,"error":"api","message":"..."}
✗ ...
```

That trailing line makes the output unparseable for exactly the pollers `notifications list-ids` was added for (#78) — a `jq` or `JSON.parse` on the output fails, so a transient API error looks like a malformed tool rather than a failed call.

## The fix

Drop the `fail()` call from the catch blocks of `notifications list-ids`, `threads list-ids` and `ugeplan fetch`. The error payload already carries the message, and the non-zero exit code still signals the failure — so callers get one parseable JSON document on stdout in both the success and failure case.

Each site has a comment explaining why `fail()` is deliberately absent, so it doesn't get "helpfully" added back.

Verified: `pnpm typecheck` clean, `pnpm lint` exits 0, `bun test` 271 pass / 1 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nJqc1ztzhKN8P1Cchcwfr