### PR TITLE
fix(min-uddannelse): send unilogin userIds in childFilter, not numeric child ids

### DIFF
--- a/packages/aula-client/src/integrations/integrations.test.ts
+++ b/packages/aula-client/src/integrations/integrations.test.ts
@@ -269,9 +269,40 @@ describe('MinUddannelseClient.getOpgaver', () => {
     const client = new MinUddannelseClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
     await client.getOpgaver(ctx({ childIds: [10, 20, 30] }));
     const url = http.requested[0]?.url ?? '';
-    expect(url).toContain('childFilter=10%2C20%2C30');
+    expect(url).toContain('childFilter=u10%2Cu20%2Cu30');
     expect(url).toContain('userProfile=guardian');
     expect(http.requested[0]?.headers?.authorization).toBe('Bearer TKN-1');
+  });
+
+  test('childFilter carries the unilogin userIds, not the numeric child ids', async () => {
+    const http = new FakeHttp().enqueue({ status: 200, body: '{"personer":[]}' });
+    const client = new MinUddannelseClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
+    await client.getUgebrev(
+      ctx({ childIds: [111293, 222384], childUserIds: ['thit0305', 'emil1102'] }),
+    );
+    const url = http.requested[0]?.url ?? '';
+    expect(url).toContain('childFilter=thit0305%2Cemil1102');
+    expect(url).not.toContain('111293');
+    expect(url).not.toContain('222384');
+  });
+
+  test('a child without a resolved unilogin is skipped with a warning', async () => {
+    const http = new FakeHttp().enqueue({ status: 200, body: '{"opgaver":[]}' });
+    const client = new MinUddannelseClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
+    const plan = await client.getOpgaver(
+      ctx({ childIds: [10, 20], childUserIds: ['thit0305', ''] }),
+    );
+    expect(http.requested[0]?.url ?? '').toContain('childFilter=thit0305&');
+    expect(plan.warnings?.[0]).toContain('child 20');
+  });
+
+  test('fails loudly when no unilogin userId was resolved (never falls back to numeric ids)', async () => {
+    const http = new FakeHttp().enqueue({ status: 200, body: '{"opgaver":[]}' });
+    const client = new MinUddannelseClient({ http: http.asHttpClient(), widgets: fakeWidgets() });
+    await expect(
+      client.getOpgaver(ctx({ childIds: [10, 20], childUserIds: ['', ''] })),
+    ).rejects.toThrow(/childUserIds/);
+    expect(http.requested).toHaveLength(0);
   });
 });
 

--- a/packages/aula-client/src/integrations/min-uddannelse.ts
+++ b/packages/aula-client/src/integrations/min-uddannelse.ts
@@ -5,7 +5,8 @@
  *   0030 — opgaveliste
  *
  * Both endpoints expect `Authorization: Bearer <widget-token>` and a long
- * query string with childFilter (comma-separated) + sessionUUID.
+ * query string with childFilter (comma-separated unilogin userIds) +
+ * sessionUUID.
  */
 
 import type { AulaHttpClient } from '@aula-mcp/aula-auth';
@@ -40,6 +41,35 @@ interface MuUgebrevResponse {
   }>;
 }
 
+/**
+ * Min Uddannelse keys `childFilter` on the child's unilogin userId (the
+ * opaque `ctx.childUserIds` token), NOT the numeric Aula child profile id.
+ * A numeric id is not rejected — MU answers HTTP 200 with empty
+ * `personer`/`opgaver`, so the bug looks like "the school published
+ * nothing" (issue #74). scaarup/aula sends `",".join(self._childuserids)`
+ * for both widgets, same as here.
+ *
+ * Because a wrong filter fails silently there is no useful numeric
+ * fallback: sending `childIds` just reproduces the empty-200. Children with
+ * no resolved userId are dropped with a warning (as EasyIQ does), and if
+ * that leaves nothing we fail loudly rather than return a confident `[]`.
+ */
+function resolveChildFilter(ctx: IntegrationContext): { childFilter: string; warnings: string[] } {
+  const warnings: string[] = [];
+  const ids: string[] = [];
+  for (let i = 0; i < ctx.childIds.length; i++) {
+    const userId = ctx.childUserIds?.[i];
+    if (userId && userId.length > 0) ids.push(userId);
+    else warnings.push(`child ${ctx.childIds[i]}: no unilogin userId resolved; skipped`);
+  }
+  if (ids.length === 0) {
+    throw new Error(
+      'Min Uddannelse needs the per-child unilogin userIds (childUserIds); none were resolved for the requested children',
+    );
+  }
+  return { childFilter: ids.join(','), warnings };
+}
+
 export interface MinUddannelseOptions {
   http: AulaHttpClient;
   widgets: WidgetTokenManager;
@@ -64,8 +94,9 @@ export class MinUddannelseClient {
   }
 
   async getOpgaver(ctx: IntegrationContext): Promise<NormalisedWeekPlan> {
+    const { childFilter, warnings } = resolveChildFilter(ctx);
     const result = await this.widgets.withRetry(this.widgetIdOpgaver, async (token) =>
-      this.fetchMu<MuOpgaverResponse>(MU_OPGAVER, ctx, token),
+      this.fetchMu<MuOpgaverResponse>(MU_OPGAVER, ctx, childFilter, token),
     );
     const items: NormalisedWeekPlanItem[] = [];
     for (const o of result.opgaver ?? []) {
@@ -78,12 +109,13 @@ export class MinUddannelseClient {
       if (o.forloeb?.navn) item.content = o.forloeb.navn;
       items.push(item);
     }
-    return { items, raw: result };
+    return { items, raw: result, ...(warnings.length ? { warnings } : {}) };
   }
 
   async getUgebrev(ctx: IntegrationContext): Promise<NormalisedWeekPlan> {
+    const { childFilter, warnings } = resolveChildFilter(ctx);
     const result = await this.widgets.withRetry(this.widgetIdUgebrev, async (token) =>
-      this.fetchMu<MuUgebrevResponse>(MU_UGEBREV, ctx, token),
+      this.fetchMu<MuUgebrevResponse>(MU_UGEBREV, ctx, childFilter, token),
     );
     const items: NormalisedWeekPlanItem[] = [];
     for (const person of result.personer ?? []) {
@@ -97,17 +129,18 @@ export class MinUddannelseClient {
         }
       }
     }
-    return { items, raw: result };
+    return { items, raw: result, ...(warnings.length ? { warnings } : {}) };
   }
 
   private async fetchMu<T>(
     base: string,
     ctx: IntegrationContext,
+    childFilter: string,
     token: string,
   ): Promise<T | { _expired: true; status: number; bodySnippet: string }> {
     const params = new URLSearchParams({
       assuranceLevel: '2',
-      childFilter: ctx.childIds.join(','),
+      childFilter,
       currentWeekNumber: ctx.isoWeek,
       isMobileApp: 'false',
       placement: 'narrow',


### PR DESCRIPTION
## Root cause

`fetchMu()` in `packages/aula-client/src/integrations/min-uddannelse.ts` built the query string with `childFilter: ctx.childIds.join(',')` — the **numeric Aula child profile ids**.

The MinUddannelse widgets (0029 ugebrev, 0030 opgaveliste) key `childFilter` on the child's **unilogin userId**. Unlike Meebook — which 400s with "Fandt et unilogin i child filter med et ugyldigt format" when you hand it a number — MU accepts the numeric id and answers **HTTP 200 with empty `personer` / `opgaver`**. So `aula.ugebrev.minuddannelse` and `aula.opgaver.minuddannelse` both returned a confident `{ "items": [] }` that looked exactly like "the school published nothing this week".

`ctx.childUserIds` is already resolved in `buildIntegrationCtx()` (`packages/mcp-server/src/tools.ts`) from `getProfilesByLogin()` — it just was never wired into this one integration. The Python reference does the same thing: `client.py` builds `childUserIds = ",".join(self._childuserids)` and passes it to both the `/opgaveliste` and `/ugebrev` payloads.

## The fix

A small `resolveChildFilter(ctx)` helper now builds the CSV from `ctx.childUserIds`, with a comment at the call site explaining why so nobody "helpfully" reverts it.

### On the suggested fallback

The reported one-liner was:

```ts
childFilter: (ctx.childUserIds?.some(Boolean) ? ctx.childUserIds : ctx.childIds).join(','),
```

I went with a stricter variant, for two reasons:

1. **The numeric fallback is not a fallback here — it's the bug.** Meebook can afford `userId || String(childId)` because a bad unilogin comes back as a loud 400. MU returns 200-with-nothing, so falling back to numeric ids just reproduces the silent empty result the issue is about. Better to fail loudly than to answer `[]` as if it were data.
2. **`.some(Boolean)` is all-or-nothing per array.** With `['thit0305', '']` (one child resolved, one not — plausible in the two-institution case) it sends `childFilter=thit0305,`, i.e. a trailing empty segment, rather than dropping the unresolved child.

So instead, matching what EasyIQ SkolePortal/Lektier already do: children with no resolved userId are **skipped with a per-child `warnings` entry**, and if that leaves the filter empty we **throw** with a message naming `childUserIds`, rather than issuing a request that cannot match.

## Credit

Diagnosis by @Khaniyan1 in #74 — root cause, the `meebook.ts` / scaarup precedent, and the redacted wire transcript showing the numeric id on the query string were all in the report. They also offered to test against a live guardian account with children at **two institutions**, which is the interesting case for the partial-resolution path above; that verification would be very welcome before/after merge.

## Tests

New cases in `packages/aula-client/src/integrations/integrations.test.ts`, asserting on the captured wire request from the existing `FakeHttp` fake:

- `childFilter` carries the unilogin ids and the numeric ids appear nowhere in the URL
- a child with no resolved unilogin is dropped and surfaces as a warning
- all-unresolved throws and issues no HTTP request at all

`pnpm typecheck`, `pnpm lint`, `pnpm test` all green (289 tests, 0 fail).

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)