### PR TITLE
fix(auth): name STIL's bot-defense block instead of "unexpected host"

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ ssh aula
 aula login
 ```
 
+> ⚠️ **Kører du på en VPS eller i skyen? Så virker A måske ikke.**
+>
+> STIL har sat en bot-beskyttelse (de kalder den NDBD) foran Unilogin-brokeren. Den svarer med en JavaScript-udfordring i stedet for at føre login-kæden videre, og `aula login` fejler med `Login blocked by STIL's bot protection`. Den udløses typisk på datacenter- og hosting-IP'er — hjemmeforbindelser går som regel lige igennem.
+>
+> Der er ikke noget at rette i `aula-mcp`: udfordringen kræver en rigtig browser, og det her projekt kører bevidst ren HTTP uden headless browser. En anden user-agent hjælper ikke.
+>
+> **Brug metode B i stedet.** Log ind hjemmefra og flyt tokens over. Fornyelse af access token går direkte til `login.aula.dk` og rører aldrig brokeren, så serveren kører videre af sig selv bagefter.
+
 B. *Eksportér tokens fra din Mac (eller fra hvor du allerede er logget ind).* macOS Keychain kan ikke flyttes mellem maskiner, så `aula tokens export` re-krypterer dem til en bærbar fil-bundle.
 
 ```sh

--- a/packages/aula-auth/src/aula-login-client.test.ts
+++ b/packages/aula-auth/src/aula-login-client.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+import { AulaBotDefenseError, botDefenseMessage, isBotDefenseHost } from './aula-login-client.ts';
+
+/**
+ * STIL put a bot-defense gateway in front of the Unilogin broker (#83). The
+ * chain walker cannot get past it and is not meant to try — what matters is
+ * that it says so clearly instead of reporting a generic unexpected host,
+ * because the fix is operational (log in elsewhere, move the tokens) rather
+ * than something the user can change in the client.
+ */
+describe('bot-defense detection', () => {
+  test('recognises the STIL security-check host', () => {
+    expect(isBotDefenseHost('security-check.stil.dk')).toBe(true);
+  });
+
+  test('does not swallow the ordinary hosts in the chain', () => {
+    expect(isBotDefenseHost('broker.unilogin.dk')).toBe(false);
+    expect(isBotDefenseHost('nemlog-in.mitid.dk')).toBe(false);
+    expect(isBotDefenseHost('login.aula.dk')).toBe(false);
+    // Nor a lookalike that merely mentions the domain.
+    expect(isBotDefenseHost('security-check.stil.dk.evil.example')).toBe(false);
+  });
+});
+
+describe('botDefenseMessage', () => {
+  const msg = botDefenseMessage('security-check.stil.dk', 3);
+
+  test('names the host and the hop it happened at', () => {
+    expect(msg).toContain('security-check.stil.dk');
+    expect(msg).toContain('hop 3');
+  });
+
+  test('says plainly that this is upstream, not a local bug', () => {
+    expect(msg).toContain('not a bug in aula-mcp');
+  });
+
+  test('heads off the two things people try first', () => {
+    // The user-agent is the usual first guess, and it does not help.
+    expect(msg).toContain('user-agent');
+    expect(msg).toContain('datacenter');
+  });
+
+  test('gives the workaround that actually works', () => {
+    expect(msg).toContain('aula tokens export');
+    // Refresh never touches the broker, which is why the workaround holds.
+    expect(msg).toContain('never touches the broker');
+  });
+});
+
+describe('AulaBotDefenseError', () => {
+  test('is distinguishable from a generic login failure', () => {
+    const err = new AulaBotDefenseError(botDefenseMessage('security-check.stil.dk', 3));
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('AulaBotDefenseError');
+  });
+});

--- a/packages/aula-auth/src/aula-login-client.ts
+++ b/packages/aula-auth/src/aula-login-client.ts
@@ -88,6 +88,60 @@ export class AulaLoginError extends AulaAuthError {
 }
 
 /**
+ * Thrown when the login chain is intercepted by STIL's bot-protection
+ * gateway instead of reaching MitID. Separate from AulaLoginError so
+ * callers can tell "we were blocked" apart from "the flow broke".
+ */
+export class AulaBotDefenseError extends AulaAuthError {
+  override readonly name: string = 'AulaBotDefenseError';
+}
+
+/**
+ * STIL fronts the Unilogin broker with a bot-defense gateway they call NDBD.
+ * When it decides a request looks automated it answers with a JavaScript
+ * challenge page rather than continuing the redirect chain, and the chain
+ * walker sees a host it has no branch for.
+ *
+ * There is deliberately no attempt to solve it. The challenge computes a
+ * cookie from obfuscated JavaScript that probes browser and DOM properties,
+ * so a pure-HTTP client has nothing to follow — no Location, no
+ * meta-refresh — and this package does not drive a headless browser by
+ * design. Reported cases have come from datacenter/hosting IPs while home
+ * connections pass straight through, which points at network reputation
+ * rather than anything the client sends.
+ *
+ * So: name it, and point at the workaround that does work.
+ */
+const BOT_DEFENSE_HOSTS: ReadonlySet<string> = new Set(['security-check.stil.dk']);
+
+/** Exported for tests — pins the host list this behaviour keys on. */
+export function isBotDefenseHost(host: string): boolean {
+  return BOT_DEFENSE_HOSTS.has(host);
+}
+
+export function botDefenseMessage(host: string, hop: number): string {
+  return [
+    `Login blocked by STIL's bot protection (${host}) at hop ${hop}.`,
+    '',
+    'This is an upstream security gateway, not a bug in aula-mcp. It serves a',
+    'JavaScript challenge that a pure-HTTP client cannot solve, and it usually',
+    'triggers on requests from datacenter or hosting IPs rather than home',
+    'connections. Changing the user-agent does not help.',
+    '',
+    'Running on a VPS, cloud host or CI? Log in on a home machine and move the',
+    'tokens across:',
+    '',
+    '  aula login',
+    '  aula tokens export ./aula-bundle',
+    '  scp ./aula-bundle/tokens.json ./aula-bundle/.key user@server:/var/lib/aula-mcp/',
+    '',
+    'Token refresh talks straight to login.aula.dk and never touches the broker,',
+    'so the server keeps refreshing on its own from there. See the self-hosting',
+    'section of the README.',
+  ].join('\n');
+}
+
+/**
  * Thrown by attemptSilentReauthorize when the broker/MitID session has
  * lapsed and a fresh interactive login is required. Callers should fall
  * back to the full login() flow.
@@ -297,6 +351,9 @@ export class AulaLoginClient {
           currentUrl = new URL(metaUrl, currentUrl).toString();
           continue;
         }
+        if (isBotDefenseHost(url.host)) {
+          throw new AulaBotDefenseError(botDefenseMessage(url.host, hop));
+        }
         throw new AulaLoginError(
           `Silent SSO landed on unexpected host (${url.host}) at hop ${hop}`,
         );
@@ -372,6 +429,9 @@ export class AulaLoginClient {
           currentMethod = 'GET';
           currentBody = undefined;
           continue;
+        }
+        if (isBotDefenseHost(url.host)) {
+          throw new AulaBotDefenseError(botDefenseMessage(url.host, hop));
         }
         throw new AulaLoginError(
           `OAuth chain landed on unexpected host (${url.host}) at hop ${hop}`,

--- a/packages/aula-auth/src/index.ts
+++ b/packages/aula-auth/src/index.ts
@@ -1,12 +1,15 @@
 export {
   type AulaAuthMethod,
+  AulaBotDefenseError,
   AulaLoginClient,
   type AulaLoginClientOptions,
   type AulaLoginCredentials,
   AulaLoginError,
   type AulaLoginOptions,
   AulaSilentSsoFailedError,
+  botDefenseMessage,
   type IdentitySelector,
+  isBotDefenseHost,
 } from './aula-login-client.ts';
 export {
   type AulaOAuthConfig,


### PR DESCRIPTION
## What's happening

Reported in #83. STIL has put a bot-defense gateway in front of the Unilogin broker — they call it NDBD; the challenge page's markers (`bobcmn`, `TSPD_101`, `DOSL7`, `/TSPD/`) identify it as F5 BIG-IP Advanced WAF proactive bot defense. When it decides a request looks automated it serves a JavaScript challenge instead of continuing the redirect chain, so `walkOauthChain` lands on `security-check.stil.dk` with no branch for it and throws a generic *"OAuth chain landed on unexpected host"*.

That message tells the user nothing useful. The cause isn't in our code and the fix isn't in our code either, so the error should say so.

## What this does *not* do

It does not try to pass the challenge, and that's deliberate:

- The challenge computes a cookie from obfuscated JavaScript that probes browser and DOM properties. The page has no `Location` and no meta-refresh — there is genuinely nothing for a pure-HTTP client to follow.
- `packages/aula-auth` is *"pure HTTP, no headless browser"* by design. Solving this would mean a browser, which contradicts that. And headless detection is exactly what F5's product is built to do, so it likely wouldn't work anyway.
- Changing the user-agent doesn't help — verified by reproducing the chain with bare `curl` defaults and no headers at all, which passed cleanly.

## Evidence it's environment-specific

Reproduced the full chain from a Danish residential connection: `login.aula.dk` → `broker.unilogin.dk` IdP page directly, no NDBD hop. A complete `aula login` also succeeds on current `main` from a home connection. The reporter is on an Ubuntu cloud box, and datacenter/hosting ASNs are a well-known trigger for risk-based challenges like this.

Worth being honest about the limit of that: STIL's exact trigger rule isn't visible from outside. If a report ever arrives from a residential connection, this calculus changes and the issue should be reopened.

## The change

- New `AulaBotDefenseError`, so callers can tell "we were blocked" apart from "the flow broke".
- Both `walkOauthChain` and `attemptSilentReauthorize` check the host before falling through to the generic throw.
- The message names the gateway, states plainly that it's upstream, heads off the user-agent guess, and gives the workaround that works.
- README gains the same note beside the self-hosting token instructions.

## Why the workaround holds

`refreshAccessToken` POSTs straight to `login.aula.dk/.../token.php` and never touches `broker.unilogin.dk`. Only `login` and `refresh-stepup` walk the broker chain. So logging in on a home machine, then `aula tokens export` / `scp` to the server, leaves the server refreshing indefinitely — self-hosting on a VPS stays fully supported.

Tests pin the host list, the message content, and the error's identity — the host list is the kind of thing that silently rots.

`pnpm typecheck` clean, `pnpm lint` clean, `bun test` 305 pass / 1 skip / 0 fail.

Refs #83 — leaving the issue open until the reporter confirms the message is actually useful to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nJqc1ztzhKN8P1Cchcwfr