### PR TITLE
fix(auth): redact access_token in debug logs and error URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Komplet hjælp med eksempler: `pnpm aula --help`
 | `AULA_MCP_DIR` | `~/.config/aula-mcp` | Konfig-mappe (fil-backend + transcripts + login-log). |
 | `AULA_MCP_RAW=1` | off | Aktiverer `aula.raw_request` escape-hatch-toolet. |
 | `AULA_MCP_WRITE=1` | off | Aktiverer skrive-tools (`aula.presence.set_template` — sæt komme/gå-tider). Serveren er read-only uden den. |
-| `AULA_MCP_LOG=1` | off | Verbose console-logs fra auth/client-lagene. |
+| `AULA_MCP_LOG=1` | off | Verbose console-logs fra auth/client-lagene (samme redaktion som wire-transcripts). |
 | `AULA_MCP_ALLOW_REMOTE=1` | off | Tillader at binde til ikke-loopback adresser (fx bag en reverse proxy). |
 
 ### Wire-transcripts
@@ -362,6 +362,8 @@ Komplet hjælp med eksempler: `pnpm aula --help`
 `--debug`-tilstand tee'r en JSONL-transcript af hvert HTTP-request/response til `~/.config/aula-mcp/transcripts/login-<timestamp>.jsonl`. Cookies, OAuth/SAML-payloads, MitID-auth-koder, adgangskoder, M1, flowValueProof, `access_token`-query-parameter og andre hemmelige felter bliver alle redaktet (`<redacted N chars>`). Transcripten kan trygt vedhæftes en GitHub-issue.
 
 `aula transcript view <file>` pretty-printer en af dem.
+
+Den samme redaktion gælder console-logs fra `AULA_MCP_LOG=1` og `aula login --debug` — request-URL'er bliver renset, før de skrives, så `access_token`-query-parameteren aldrig lander i en terminal-log.
 
 ---
 

--- a/packages/aula-auth/src/aula-login-client.ts
+++ b/packages/aula-auth/src/aula-login-client.ts
@@ -46,6 +46,7 @@ import type { AvailableAuthenticators } from './mitid-types.ts';
 import { mitidUrls } from './mitid-urls.ts';
 import { generatePkce } from './pkce.ts';
 import { generateState } from './state.ts';
+import { sanitizeUrl } from './wire-tracer.ts';
 
 export type AulaAuthMethod = 'APP' | 'CODE_TOKEN';
 
@@ -131,7 +132,7 @@ export class AulaLoginClient {
       codeChallenge: pkce.challenge,
     });
     this.logger.info('aula.login.start', { method, username: opts.username });
-    this.logger.debug('oauth.authorize_url', { authorizeUrl });
+    this.logger.debug('oauth.authorize_url', { authorizeUrl: sanitizeUrl(authorizeUrl) });
 
     // 2. Walk OAuth redirect chain → broker page or MitID page.
     const reachedMitid = await this.walkOauthChain(authorizeUrl);
@@ -239,12 +240,16 @@ export class AulaLoginClient {
       codeChallenge: pkce.challenge,
     });
     this.logger.info('aula.silent_reauthorize.start');
-    this.logger.debug('oauth.silent.authorize_url', { authorizeUrl });
+    this.logger.debug('oauth.silent.authorize_url', { authorizeUrl: sanitizeUrl(authorizeUrl) });
 
     let currentUrl = authorizeUrl;
     for (let hop = 0; hop < 15; hop++) {
       const res = await this.http.request(currentUrl, { method: 'GET' });
-      this.logger.debug('oauth.silent.hop', { hop, status: res.status, url: currentUrl });
+      this.logger.debug('oauth.silent.hop', {
+        hop,
+        status: res.status,
+        url: sanitizeUrl(currentUrl),
+      });
 
       if (res.status >= 300 && res.status < 400) {
         const loc = res.headers.get('location');
@@ -263,7 +268,7 @@ export class AulaLoginClient {
           }
           if (!code) {
             throw new AulaSilentSsoFailedError(
-              `Silent SSO terminus had no code in URL: ${next.slice(0, 200)}`,
+              `Silent SSO terminus had no code in URL: ${sanitizeUrl(next).slice(0, 200)}`,
             );
           }
           this.logger.info('aula.silent_reauthorize.code_received');
@@ -332,7 +337,11 @@ export class AulaLoginClient {
         method: currentMethod,
         ...(currentBody ? { body: currentBody } : {}),
       });
-      this.logger.debug('oauth.chain.hop', { hop, status: res.status, url: currentUrl });
+      this.logger.debug('oauth.chain.hop', {
+        hop,
+        status: res.status,
+        url: sanitizeUrl(currentUrl),
+      });
 
       // 3xx — follow Location.
       if (res.status >= 300 && res.status < 400) {
@@ -367,7 +376,7 @@ export class AulaLoginClient {
         // "unexpected host" on perfectly valid pages.
         const metaUrl = extractMetaRefreshUrl(res.body);
         if (metaUrl) {
-          this.logger.debug('oauth.chain.meta_refresh', { metaUrl });
+          this.logger.debug('oauth.chain.meta_refresh', { metaUrl: sanitizeUrl(metaUrl) });
           currentUrl = new URL(metaUrl, currentUrl).toString();
           currentMethod = 'GET';
           currentBody = undefined;
@@ -612,7 +621,9 @@ export class AulaLoginClient {
       if (res.url.startsWith(this.oauth.redirectUri) && res.url.includes('code=')) {
         return res.url;
       }
-      throw new AulaLoginError(`Aula ACS chain stopped at status ${res.status} on ${res.url}`);
+      throw new AulaLoginError(
+        `Aula ACS chain stopped at status ${res.status} on ${sanitizeUrl(res.url)}`,
+      );
     }
     throw new AulaLoginError('Aula ACS chain exceeded 10 hops');
   }

--- a/packages/aula-auth/src/aula-oauth.ts
+++ b/packages/aula-auth/src/aula-oauth.ts
@@ -10,6 +10,7 @@ import { AulaAuthError } from './errors.ts';
 import type { AulaHttpClient } from './http.ts';
 import type { Logger } from './logger.ts';
 import { silentLogger } from './logger.ts';
+import { sanitizeUrl } from './wire-tracer.ts';
 
 export interface AulaOAuthConfig {
   /** Aula's mobile-app OAuth client ID. */
@@ -205,8 +206,10 @@ export function parseAuthorizationCallback(url: string): { code: string; state: 
   const u = new URL(url);
   const code = u.searchParams.get('code');
   const state = u.searchParams.get('state');
-  if (!code) throw new OAuthError(`Authorization callback missing code: ${url}`);
-  if (!state) throw new OAuthError(`Authorization callback missing state: ${url}`);
+  // Sanitised: whichever of code/state IS present is a credential, and this
+  // message reaches the login log and any bug report pasted from it.
+  if (!code) throw new OAuthError(`Authorization callback missing code: ${sanitizeUrl(url)}`);
+  if (!state) throw new OAuthError(`Authorization callback missing state: ${sanitizeUrl(url)}`);
   return { code, state };
 }
 

--- a/packages/aula-auth/src/errors.ts
+++ b/packages/aula-auth/src/errors.ts
@@ -2,6 +2,9 @@
  * Base error for everything the auth package throws.
  * Subclass for distinct failure modes that callers should branch on.
  */
+
+import { sanitizeUrl } from './wire-tracer.ts';
+
 export class AulaAuthError extends Error {
   override readonly name: string = 'AulaAuthError';
   override readonly cause: unknown;
@@ -14,11 +17,16 @@ export class AulaAuthError extends Error {
 
 export class RedirectLoopError extends AulaAuthError {
   override readonly name: string = 'RedirectLoopError';
+  /** Sanitised — the URL we got stuck on may carry `?code=` or `?access_token=`,
+   *  and this message ends up in the login log and in issue reports. */
+  readonly lastUrl: string;
   constructor(
     public readonly hops: number,
-    public readonly lastUrl: string,
+    lastUrl: string,
   ) {
-    super(`Exceeded ${hops} redirect hops; stuck at ${lastUrl}`);
+    const safeUrl = sanitizeUrl(lastUrl);
+    super(`Exceeded ${hops} redirect hops; stuck at ${safeUrl}`);
+    this.lastUrl = safeUrl;
   }
 }
 

--- a/packages/aula-auth/src/http.test.ts
+++ b/packages/aula-auth/src/http.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { AulaHttpClient } from './http.ts';
+import type { Logger } from './logger.ts';
+import { InMemoryTracer } from './wire-tracer.ts';
+
+/**
+ * End-to-end guard for the leak path in #86: Aula puts `access_token` in the
+ * query string, so the request URL itself is a credential. The client must
+ * hand a sanitised URL to both the wire tracer AND the logger — the latter
+ * matters because `AULA_MCP_LOG=1` / `aula login --debug` point a real sink
+ * at it, and a caller-supplied logger does no redaction of its own.
+ */
+
+/** Stand-in for a real bearer JWT. No test may let this string survive. */
+const JWT = 'eyJhbGciOiJSUzI1NiJ9.PAYLOAD.SIGNATURE';
+const API_URL = `https://www.aula.dk/api/v22/?method=messaging.getThreads&access_token=${JWT}`;
+
+interface CapturedLog {
+  level: string;
+  message: string;
+  meta?: Record<string, unknown>;
+}
+
+function capturingLogger(sink: CapturedLog[]): Logger {
+  return {
+    debug: (message, meta) => sink.push({ level: 'debug', message, ...(meta ? { meta } : {}) }),
+    info: (message, meta) => sink.push({ level: 'info', message, ...(meta ? { meta } : {}) }),
+    warn: (message, meta) => sink.push({ level: 'warn', message, ...(meta ? { meta } : {}) }),
+    error: (message, meta) => sink.push({ level: 'error', message, ...(meta ? { meta } : {}) }),
+  };
+}
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+/** Replace global fetch; records the URLs it was called with. */
+function stubFetch(response: Response | (() => never)): string[] {
+  const seen: string[] = [];
+  globalThis.fetch = ((input: string | URL | Request) => {
+    seen.push(String(input));
+    if (typeof response === 'function') return Promise.reject(new Error('connection refused'));
+    return Promise.resolve(response.clone());
+  }) as typeof fetch;
+  return seen;
+}
+
+describe('AulaHttpClient logging', () => {
+  test('logs a redacted URL, and still sends the real one', async () => {
+    const seen = stubFetch(new Response('{}', { status: 200 }));
+    const logs: CapturedLog[] = [];
+    const client = new AulaHttpClient({ logger: capturingLogger(logs) });
+
+    await client.request(API_URL);
+
+    // The wire is untouched — only the log line is scrubbed.
+    expect(seen[0]).toBe(API_URL);
+    const serialised = JSON.stringify(logs);
+    expect(serialised).not.toContain(JWT);
+    expect(serialised).not.toContain('SIGNATURE');
+    expect(serialised).toContain('http.request');
+    expect(serialised).toContain('messaging.getThreads');
+  });
+
+  test('logs a redacted URL on a network error too', async () => {
+    stubFetch(() => {
+      throw new Error('unreachable');
+    });
+    const logs: CapturedLog[] = [];
+    const client = new AulaHttpClient({ logger: capturingLogger(logs) });
+
+    await expect(client.request(API_URL)).rejects.toThrow();
+    expect(JSON.stringify(logs)).not.toContain(JWT);
+  });
+
+  test('traces a redacted URL', async () => {
+    stubFetch(new Response('{}', { status: 200 }));
+    const tracer = new InMemoryTracer();
+    const client = new AulaHttpClient({ tracer });
+
+    await client.request(API_URL);
+
+    expect(JSON.stringify(tracer.entries)).not.toContain(JWT);
+    expect(tracer.entries[0]?.url).toContain('access_token=%3Credacted');
+  });
+});

--- a/packages/aula-auth/src/http.ts
+++ b/packages/aula-auth/src/http.ts
@@ -114,7 +114,9 @@ export class AulaHttpClient {
       }
     }
 
-    this.logger.debug('http.request', { method: init.method, url });
+    // sanitizeUrl, not the raw URL: Aula's API carries `access_token` in the
+    // query string, and a caller-supplied logger won't necessarily redact it.
+    this.logger.debug('http.request', { method: init.method, url: sanitizeUrl(url) });
     const start = Date.now();
     const seq = ++this.seq;
     let response: Response;
@@ -141,7 +143,7 @@ export class AulaHttpClient {
           durationMs,
         });
       }
-      this.logger.error('http.network_error', { url, error: message });
+      this.logger.error('http.network_error', { url: sanitizeUrl(url), error: message });
       throw e;
     }
     await this.jar.storeFromResponse(response.headers, url);

--- a/packages/aula-auth/src/index.ts
+++ b/packages/aula-auth/src/index.ts
@@ -151,9 +151,13 @@ export {
   InMemoryTracer,
   JsonlFileTracer,
   noopTracer,
+  SECRET_BODY_FIELD_NAMES,
+  SECRET_URL_PARAM_NAMES,
   sanitizeHeaders,
+  sanitizeLogMeta,
   sanitizeRequestBody,
   sanitizeResponseBody,
+  sanitizeUrl,
   type WireEntry,
   type WireTracer,
 } from './wire-tracer.ts';

--- a/packages/aula-auth/src/logger.test.ts
+++ b/packages/aula-auth/src/logger.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { consoleLogger, silentLogger, stderrLogger } from './logger.ts';
+
+/**
+ * The README tells people a `--debug` trace (and `AULA_MCP_LOG=1` output) is
+ * safe to attach to a GitHub issue. These tests hold the sinks to that
+ * promise: no bearer token, in a meta field or inside a URL, may reach the
+ * console or stderr.
+ */
+
+/** Stand-in for a real bearer JWT. No test may let this string survive. */
+const JWT = 'eyJhbGciOiJSUzI1NiJ9.PAYLOAD.SIGNATURE';
+const API_URL = `https://www.aula.dk/api/v22/?method=messaging.getThreads&access_token=${JWT}`;
+
+const originalConsole = {
+  debug: console.debug,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+};
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+afterEach(() => {
+  console.debug = originalConsole.debug;
+  console.info = originalConsole.info;
+  console.warn = originalConsole.warn;
+  console.error = originalConsole.error;
+  process.stderr.write = originalStderrWrite;
+});
+
+/** Swap all four console methods for a collector and return what was written. */
+function captureConsole(run: () => void): string {
+  const lines: string[] = [];
+  const sink = (...args: unknown[]): void => {
+    lines.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+  };
+  console.debug = sink;
+  console.info = sink;
+  console.warn = sink;
+  console.error = sink;
+  run();
+  return lines.join('\n');
+}
+
+function captureStderr(run: () => void): string {
+  const chunks: string[] = [];
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    chunks.push(typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+  run();
+  return chunks.join('');
+}
+
+describe('consoleLogger', () => {
+  test('never emits an access_token carried in a request URL', () => {
+    const out = captureConsole(() => {
+      consoleLogger('test').debug('http.request', { method: 'GET', url: API_URL });
+    });
+    expect(out).not.toContain(JWT);
+    expect(out).not.toContain('SIGNATURE');
+    expect(out).toContain('messaging.getThreads');
+  });
+
+  test('never emits a token passed as a meta field, at any level', () => {
+    const out = captureConsole(() => {
+      const log = consoleLogger('test');
+      log.info('oauth.tokens', { access_token: JWT, refresh_token: JWT, id_token: JWT });
+      log.warn('oauth.nested', { record: { tokens: { access_token: JWT } } });
+      log.error('oauth.failed', { url: `https://example.com/cb?code=AUTHCODE&state=STATE` });
+    });
+    expect(out).not.toContain(JWT);
+    expect(out).not.toContain('AUTHCODE');
+    expect(out).not.toContain('STATE');
+  });
+});
+
+describe('stderrLogger', () => {
+  test('never emits an access_token carried in a request URL', () => {
+    const out = captureStderr(() => {
+      stderrLogger('test').debug('http.request', { method: 'GET', url: API_URL });
+    });
+    expect(out).not.toContain(JWT);
+    expect(out).toContain('http.request');
+    expect(out).toContain('messaging.getThreads');
+  });
+
+  test('never emits a token passed as a meta field', () => {
+    const out = captureStderr(() => {
+      stderrLogger('test').error('token-store.refresh.failed', { refresh_token: JWT });
+    });
+    expect(out).not.toContain(JWT);
+    expect(out).toContain('<redacted');
+  });
+});
+
+describe('silentLogger', () => {
+  test('writes nothing at all', () => {
+    const out = captureConsole(() => {
+      silentLogger.debug('http.request', { url: API_URL });
+    });
+    expect(out).toBe('');
+  });
+});

--- a/packages/aula-auth/src/logger.ts
+++ b/packages/aula-auth/src/logger.ts
@@ -1,7 +1,15 @@
 /**
  * Minimal structured logger interface. Callers pass their own (pino, console,
  * MCP transport, etc.). Default is silent so tests + libraries don't spam.
+ *
+ * The two concrete sinks below run every `meta` through `sanitizeLogMeta`
+ * first. `AULA_MCP_LOG=1` and `aula login --debug` both point at them, and the
+ * meta they carry routinely contains request URLs — which, for Aula, means
+ * `?access_token=<JWT>`. Redacting at the sink (rather than only at the call
+ * site) means a new `logger.debug` added later can't silently start leaking.
  */
+
+import { sanitizeLogMeta } from './wire-tracer.ts';
 
 export interface Logger {
   debug(message: string, meta?: Record<string, unknown>): void;
@@ -19,10 +27,10 @@ export const silentLogger: Logger = {
 
 export function consoleLogger(prefix = 'aula-auth'): Logger {
   return {
-    debug: (m, meta) => console.debug(`[${prefix}] ${m}`, meta ?? ''),
-    info: (m, meta) => console.info(`[${prefix}] ${m}`, meta ?? ''),
-    warn: (m, meta) => console.warn(`[${prefix}] ${m}`, meta ?? ''),
-    error: (m, meta) => console.error(`[${prefix}] ${m}`, meta ?? ''),
+    debug: (m, meta) => console.debug(`[${prefix}] ${m}`, sanitizeLogMeta(meta) ?? ''),
+    info: (m, meta) => console.info(`[${prefix}] ${m}`, sanitizeLogMeta(meta) ?? ''),
+    warn: (m, meta) => console.warn(`[${prefix}] ${m}`, sanitizeLogMeta(meta) ?? ''),
+    error: (m, meta) => console.error(`[${prefix}] ${m}`, sanitizeLogMeta(meta) ?? ''),
   };
 }
 
@@ -32,7 +40,8 @@ export function consoleLogger(prefix = 'aula-auth'): Logger {
  * default to stdout in Node/Bun, which would corrupt the protocol.
  */
 export function stderrLogger(prefix = 'aula-auth'): Logger {
-  const write = (level: string, m: string, meta?: Record<string, unknown>): void => {
+  const write = (level: string, m: string, rawMeta?: Record<string, unknown>): void => {
+    const meta = sanitizeLogMeta(rawMeta);
     const suffix = meta && Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
     process.stderr.write(`[${prefix}] ${level} ${m}${suffix}\n`);
   };

--- a/packages/aula-auth/src/wire-tracer.test.ts
+++ b/packages/aula-auth/src/wire-tracer.test.ts
@@ -2,12 +2,18 @@ import { describe, expect, test } from 'bun:test';
 import {
   formatTraceText,
   InMemoryTracer,
+  SECRET_BODY_FIELD_NAMES,
+  SECRET_URL_PARAM_NAMES,
   sanitizeHeaders,
+  sanitizeLogMeta,
   sanitizeRequestBody,
   sanitizeResponseBody,
   sanitizeUrl,
   type WireEntry,
 } from './wire-tracer.ts';
+
+/** Stand-in for a real bearer JWT. No test may let this string survive. */
+const JWT = 'eyJhbGciOiJSUzI1NiJ9.PAYLOAD.SIGNATURE';
 
 describe('sanitizeUrl', () => {
   test('redacts access_token in query string', () => {
@@ -36,6 +42,74 @@ describe('sanitizeUrl', () => {
 
   test('returns the input unchanged when not a valid URL', () => {
     expect(sanitizeUrl('not a url')).toBe('not a url');
+  });
+
+  test('redacts refresh_token and id_token too', () => {
+    const out = sanitizeUrl(`https://example.com/cb?refresh_token=${JWT}&id_token=${JWT}`);
+    expect(out).not.toContain('SIGNATURE');
+    expect(out).toContain('refresh_token=%3Credacted');
+    expect(out).toContain('id_token=%3Credacted');
+  });
+
+  test('is idempotent — a second pass keeps the first redaction verbatim', () => {
+    const once = sanitizeUrl(`https://www.aula.dk/api/v22/?access_token=${JWT}`);
+    expect(sanitizeUrl(once)).toBe(once);
+  });
+});
+
+describe('redaction denylist parity', () => {
+  // The lists are the thing that silently falls behind when Aula adds a field.
+  // Tokens travel in the query string on the API and in the body on the OAuth
+  // endpoints, so anything token-shaped has to appear in both.
+  test('every *_token field is redacted in both bodies and query strings', () => {
+    const bodyFields = new Set(SECRET_BODY_FIELD_NAMES);
+    const urlParams = new Set(SECRET_URL_PARAM_NAMES);
+    for (const name of ['access_token', 'refresh_token', 'id_token']) {
+      expect(bodyFields.has(name)).toBe(true);
+      expect(urlParams.has(name)).toBe(true);
+    }
+    for (const name of [...bodyFields, ...urlParams]) {
+      if (!name.endsWith('_token')) continue;
+      expect(bodyFields.has(name)).toBe(true);
+      expect(urlParams.has(name)).toBe(true);
+    }
+  });
+});
+
+describe('sanitizeLogMeta', () => {
+  test('scrubs the access_token out of a logged request URL', () => {
+    const meta = sanitizeLogMeta({
+      method: 'GET',
+      url: `https://www.aula.dk/api/v22/?method=messaging.getThreads&access_token=${JWT}`,
+    });
+    const serialised = JSON.stringify(meta);
+    expect(serialised).not.toContain(JWT);
+    expect(serialised).not.toContain('SIGNATURE');
+    expect(serialised).toContain('messaging.getThreads');
+    expect(meta?.method).toBe('GET');
+  });
+
+  test('redacts secret-named keys whatever the value looks like', () => {
+    const meta = sanitizeLogMeta({ access_token: JWT, refresh_token: JWT, id_token: JWT });
+    expect(JSON.stringify(meta)).not.toContain('SIGNATURE');
+    expect(meta?.access_token).toMatch(/^<redacted/);
+    expect(meta?.refresh_token).toMatch(/^<redacted/);
+    expect(meta?.id_token).toMatch(/^<redacted/);
+  });
+
+  test('recurses into nested objects and arrays', () => {
+    const meta = sanitizeLogMeta({
+      hops: [{ url: `https://broker.unilogin.dk/cb?code=AUTHCODE&access_token=${JWT}` }],
+      tokens: { access_token: JWT },
+    });
+    const serialised = JSON.stringify(meta);
+    expect(serialised).not.toContain(JWT);
+    expect(serialised).not.toContain('AUTHCODE');
+  });
+
+  test('leaves harmless meta alone and passes undefined through', () => {
+    expect(sanitizeLogMeta({ hop: 3, status: 302 })).toEqual({ hop: 3, status: 302 });
+    expect(sanitizeLogMeta(undefined)).toBeUndefined();
   });
 });
 
@@ -124,6 +198,19 @@ describe('sanitizeResponseBody', () => {
     expect(parsed.access_token).toContain('redacted');
     expect(parsed.refresh_token).toContain('redacted');
     expect(parsed.expires_in).toBe(60);
+  });
+
+  test('redacts a full OIDC token response, id_token included', () => {
+    const body = JSON.stringify({
+      access_token: JWT,
+      refresh_token: JWT,
+      id_token: JWT,
+      token_type: 'Bearer',
+      expires_in: 3600,
+    });
+    const out = sanitizeResponseBody(body);
+    expect(out.text).not.toContain('SIGNATURE');
+    expect(out.text).toContain('Bearer');
   });
 });
 

--- a/packages/aula-auth/src/wire-tracer.ts
+++ b/packages/aula-auth/src/wire-tracer.ts
@@ -105,6 +105,7 @@ const SECRET_BODY_FIELDS = [
   'authorization_code',
   'access_token',
   'refresh_token',
+  'id_token',
   'code',
   'code_verifier',
   'samlresponse',
@@ -122,13 +123,15 @@ const SECRET_BODY_FIELDS = [
 const SECRET_BODY_FIELDS_SET = new Set(SECRET_BODY_FIELDS.map((s) => s.toLowerCase()));
 
 /**
- * Query-string keys to redact in URLs before they hit a tracer. Aula's API
- * passes `access_token` as a query param (not a header), so without this the
- * --debug transcript would leak the JWT in every URL.
+ * Query-string keys to redact in URLs before they hit a tracer or a log sink.
+ * Aula's API passes `access_token` as a query param (not a header), so without
+ * this a transcript — or a single `logger.debug('http.request', { url })` —
+ * would leak the JWT in every URL.
  */
 const SECRET_URL_PARAMS = new Set([
   'access_token',
   'refresh_token',
+  'id_token',
   'code',
   'code_verifier',
   'state',
@@ -137,6 +140,20 @@ const SECRET_URL_PARAMS = new Set([
   'ticket',
   'session_code',
 ]);
+
+/**
+ * Every `*_token` field we know about must be redacted in BOTH places — the
+ * body denylist and the query-string denylist — because Aula and the broker
+ * disagree on where a token travels. Exported for the parity test that keeps
+ * the two lists from drifting when a new field shows up.
+ */
+export const SECRET_BODY_FIELD_NAMES: readonly string[] = SECRET_BODY_FIELDS;
+export const SECRET_URL_PARAM_NAMES: readonly string[] = Array.from(SECRET_URL_PARAMS);
+
+/** True for a value we already replaced — keeps sanitising idempotent. */
+function isRedacted(value: string): boolean {
+  return value.startsWith('<redacted');
+}
 
 /** Sanitise a URL by redacting known-secret query-string values. */
 export function sanitizeUrl(url: string): string {
@@ -150,11 +167,40 @@ export function sanitizeUrl(url: string): string {
   for (const key of Array.from(parsed.searchParams.keys())) {
     if (SECRET_URL_PARAMS.has(key.toLowerCase())) {
       const v = parsed.searchParams.get(key) ?? '';
+      if (isRedacted(v)) continue;
       parsed.searchParams.set(key, `<redacted ${v.length}>`);
       mutated = true;
     }
   }
   return mutated ? parsed.toString() : url;
+}
+
+/**
+ * Sanitise a logger `meta` object before it reaches a console/stderr sink.
+ * Uses the same denylists as the wire tracer: secret-named keys are replaced
+ * wholesale, and every string is run through `sanitizeUrl`, so a bare
+ * `{ url }` in a debug log is no more exposed than a token in a traced body.
+ */
+export function sanitizeLogMeta(
+  meta: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!meta) return meta;
+  return redactLogValue(meta) as Record<string, unknown>;
+}
+
+function redactLogValue(value: unknown): unknown {
+  if (typeof value === 'string') return sanitizeUrl(value);
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(redactLogValue);
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (SECRET_BODY_FIELDS_SET.has(k.toLowerCase())) {
+      out[k] = typeof v === 'string' ? `<redacted ${v.length} chars>` : `<redacted>`;
+    } else {
+      out[k] = redactLogValue(v);
+    }
+  }
+  return out;
 }
 
 /** Truncation cap for response bodies (bytes). */

--- a/packages/aula-client/src/aula-client.test.ts
+++ b/packages/aula-client/src/aula-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { AulaTokens } from '@aula-mcp/aula-auth';
 import { AulaClient } from './aula-client.ts';
-import { AulaApiVersionError, AulaStepUpRequiredError } from './errors.ts';
+import { AulaApiError, AulaApiVersionError, AulaStepUpRequiredError } from './errors.ts';
 import { FakeHttp } from './test-helpers.ts';
 
 const TOKENS: AulaTokens = {
@@ -229,6 +229,40 @@ describe('AulaClient envelope handling', () => {
     );
     const c = makeClient(http);
     await expect(c.getDailyOverview([1])).rejects.toThrow(/broke/);
+  });
+});
+
+describe('AulaClient credential leakage', () => {
+  // Aula takes the access token as a query parameter, so every API URL is a
+  // credential. AulaApiError is surfaced to MCP clients and printed by the
+  // CLI, so it must never carry the raw URL (#86).
+  test('AulaApiError never carries the raw access_token', async () => {
+    const http = new FakeHttp();
+    http.enqueue(
+      { status: 200, body: envelope([]) }, // probe
+      { status: 500, body: 'upstream exploded' },
+    );
+    const c = makeClient(http);
+    const err = (await c.getDailyOverview([1]).then(
+      () => undefined,
+      (e: unknown) => e,
+    )) as AulaApiError;
+    expect(err).toBeInstanceOf(AulaApiError);
+    expect(JSON.stringify({ message: err.message, url: err.url })).not.toContain(
+      TOKENS.access_token,
+    );
+    expect(err.url).toContain('access_token=%3Credacted');
+  });
+
+  test('a probe failure keeps the token out of the error as well', async () => {
+    const http = new FakeHttp();
+    http.enqueue({ status: 503, body: 'maintenance' });
+    const c = makeClient(http);
+    const err = (await c.ensureApiVersion().then(
+      () => undefined,
+      (e: unknown) => e,
+    )) as AulaApiError;
+    expect(err.url).not.toContain(TOKENS.access_token);
   });
 });
 

--- a/packages/aula-client/src/errors.ts
+++ b/packages/aula-client/src/errors.ts
@@ -4,7 +4,7 @@
  * focused on the kind of failure rather than which package raised it.
  */
 
-import { AulaAuthError } from '@aula-mcp/aula-auth';
+import { AulaAuthError, sanitizeUrl } from '@aula-mcp/aula-auth';
 
 export class AulaClientError extends AulaAuthError {
   override readonly name: string = 'AulaClientError';
@@ -28,12 +28,17 @@ export class AulaStepUpRequiredError extends AulaClientError {
 /** Catch-all for non-2xx responses that aren't otherwise typed. */
 export class AulaApiError extends AulaClientError {
   override readonly name: string = 'AulaApiError';
+  /** Sanitised on the way in. Every Aula API URL carries `?access_token=<JWT>`,
+   *  and this error is surfaced to MCP clients, printed by the CLI and written
+   *  to the login log — so the raw URL must never be stored here. */
+  readonly url: string;
   constructor(
     message: string,
     public readonly status: number,
-    public readonly url: string,
+    url: string,
     public readonly body?: string,
   ) {
     super(message);
+    this.url = sanitizeUrl(url);
   }
 }


### PR DESCRIPTION
Closes #86

Aula does not accept a bearer header — it takes `access_token` as a **query-string parameter** on every API call. That makes the request URL itself a live credential, and the README tells people a `--debug` trace is safe to attach to a public issue. The wire tracer already scrubbed those URLs; several other paths did not.

## What was leaking, and where

1. **The `AULA_MCP_LOG=1` / `--debug` console logger.** `AulaHttpClient.request` logged `{ method, url }` with the raw URL (`packages/aula-auth/src/http.ts`), so every single API call printed the JWT. The same applied to `http.network_error`. This is the leak the issue describes.
2. **The OAuth redirect-chain logs.** `oauth.authorize_url`, `oauth.silent.authorize_url`, `oauth.silent.hop`, `oauth.chain.hop` and `oauth.chain.meta_refresh` in `aula-login-client.ts` logged chain URLs verbatim — those carry `?code=` and `?state=` during login.
3. **The logger sinks themselves.** `consoleLogger` and `stderrLogger` printed whatever `meta` they were handed. Redacting only at call sites means the next `logger.debug` someone adds starts leaking again silently.
4. **Error objects that embed a URL.** `AulaApiError` stored the raw request URL — and that error is surfaced to MCP clients, printed by the CLI and written to `login-log.jsonl`. `RedirectLoopError`, `parseAuthorizationCallback`'s "missing code/state" errors and the silent-SSO "terminus had no code in URL" error embedded chain URLs the same way.
5. **`id_token` was missing from both denylists**, next to `access_token` / `refresh_token`.

## The fix

Extends the existing tracer redaction rather than adding a parallel mechanism, all in `wire-tracer.ts`:

- `id_token` added to `SECRET_BODY_FIELDS` and `SECRET_URL_PARAMS` (`access_token` / `refresh_token` were already in both).
- `sanitizeUrl` is now idempotent — a value already replaced isn't re-measured, so double-sanitising is safe.
- New `sanitizeLogMeta`, reusing the same denylists: secret-named keys are replaced, and every string value goes through `sanitizeUrl`, recursing into nested objects and arrays.
- `consoleLogger` and `stderrLogger` run every `meta` through it — a chokepoint, so redaction no longer depends on remembering it at each call site.
- Call sites that log a URL also sanitise explicitly, because a caller may supply their own `Logger` (pino, an MCP transport) that does no redaction.
- `AulaApiError.url` and `RedirectLoopError.lastUrl` are sanitised in the constructor; the OAuth callback/silent-SSO error messages sanitise before interpolating.

The wire is untouched — only what gets logged, traced or stored on an error is scrubbed.

## Tests

- `packages/aula-auth/src/logger.test.ts` (new): captures console + stderr and asserts a JWT never survives, whether it arrives as a meta field or inside a URL.
- `packages/aula-auth/src/http.test.ts` (new): stubs `fetch` and asserts the real URL goes on the wire while the logged and traced ones are redacted — including on a network error.
- `packages/aula-client/src/aula-client.test.ts`: `AulaApiError` never carries the raw token.
- `packages/aula-auth/src/wire-tracer.test.ts`: `id_token` coverage, `sanitizeUrl` idempotency, `sanitizeLogMeta`, a full OIDC token response, and a **denylist parity test** — any `*_token` field must appear in both the body list and the query-string list, which is what catches the list falling behind when a new field appears.

`pnpm typecheck`, `pnpm lint` and `pnpm test` all pass (317 tests, 0 failures, 0 lint errors).

## On the last to-do in the issue

I scanned the bodies of every issue and every issue comment in this repo for token-shaped strings (`eyJ…` JWTs, `access_token=`, `Bearer …`, `?code=`). Nothing matched — no traces with live credentials appear to be attached to existing issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
