### PR TITLE
fix(mcp-server): stop mangling Danish letters in attachment filenames

### DIFF
--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -708,6 +708,33 @@ describe('MCP server: tools/call(aula.messages.get_attachment)', () => {
     expect(requested).toEqual(['https://cdn.test/post-attachment']);
   });
 
+  test('keeps Danish letters in the on-disk filename', async () => {
+    // Regression guard: the sanitiser used `\w`, which is ASCII-only, so
+    // every æ, ø and å in a real Aula attachment name became an underscore
+    // — "Bålhytten" landed on disk as "B_lhytten".
+    stubFetch(() => new Response('%PDF-1.7'));
+    const out = await harness.call(31, 'aula.posts.get_attachment', {
+      postId: 42,
+      url: 'https://cdn.test/dansk',
+      filename: 'Bålhytten på Ærø - lørdag.pdf',
+    });
+    expect(out.ok).toBe(true);
+    expect(out.path).toBe(join(dir, 'post-42-Bålhytten på Ærø - lørdag.pdf'));
+    expect(dirname(out.path as string)).toBe(dir);
+  });
+
+  test('still scrubs separators and control characters from non-ASCII names', async () => {
+    // Widening the class to \p{L} must not widen what escapes the directory.
+    stubFetch(() => new Response('x'));
+    const out = await harness.call(32, 'aula.posts.get_attachment', {
+      postId: 42,
+      url: 'https://cdn.test/dansk',
+      filename: '../Bålhytten/ø\u0000.pdf',
+    });
+    expect(out.path).toBe(join(dir, 'post-42-.._Bålhytten_ø_.pdf'));
+    expect(dirname(out.path as string)).toBe(dir);
+  });
+
   test('aula.posts.get_attachment surfaces download_failed the same way', async () => {
     stubFetch(() => new Response('gone', { status: 404 }));
     const out = await harness.call(30, 'aula.posts.get_attachment', {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -67,7 +67,12 @@ async function downloadAttachmentToDisk(args: {
 
   const baseDir = process.env.AULA_MCP_ATTACHMENTS_DIR ?? join(tmpdir(), 'aula-attachments');
   await mkdir(baseDir, { recursive: true });
-  const safeName = args.filename.replace(/[^\w.\- ]+/gu, '_');
+  // `\w` is ASCII-only, so it mangled every Danish attachment it touched —
+  // "Bålhytten.pdf" landed on disk as "B_lhytten.pdf". Match Unicode letters
+  // and digits instead. Path separators, `..` traversal and control
+  // characters are still replaced, so this is no less strict: it stops
+  // punishing æ, ø and å for not being ASCII.
+  const safeName = args.filename.replace(/[^\p{L}\p{N}.\-_ ]+/gu, '_');
   const path = join(baseDir, `${args.prefix}-${safeName}`);
   await writeFile(path, buf, { mode: 0o600 });
 


### PR DESCRIPTION
Found while adding the transport tests in #89 — the agent writing them spotted it and correctly declined to write a test freezing the broken behaviour.

## The bug

`downloadAttachmentToDisk` sanitised the on-disk name with `[^\w.\- ]+`. `\w` is ASCII-only, and stays ASCII-only under the `u` flag:

```js
'Bålhytten på Ærø.pdf'.replace(/[^\w.\- ]+/gu, '_')
// → 'B_lhytten p_ _r_.pdf'
```

On a Danish school platform that hits a large share of real attachments — *Bålhytten*, *Sommerfest på Ærø*, *Forældremøde*. Files still downloaded fine; they just landed under a mangled name, which makes them harder to find and harder to hand to `aula.utils.extract_pdf_text`.

## The fix

Match Unicode letters and digits: `[^\p{L}\p{N}.\-_ ]+`.

**This is not a loosening of the traversal defence.** Path separators, `..`, and control characters are all still replaced — the only thing that changes is that non-ASCII *letters* stop being punished for not being ASCII:

```js
'../../etc/pas swd.pdf'   → '.._.._etc_pas swd.pdf'    // unchanged
'../Bålhytten/ø.pdf'      → '.._Bålhytten_ø.pdf'       // still contained
```

The existing traversal test passes untouched, and there's a new one covering a non-ASCII name carrying both a separator and a NUL byte.

Applies to `aula.messages.get_attachment` and `aula.posts.get_attachment` together, since they share the helper.

`pnpm typecheck` clean, `pnpm lint` clean, `bun test` 341 pass / 1 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nJqc1ztzhKN8P1Cchcwfr
