### PR TITLE
chore(security): pin undici to ^7.29.0 to clear 12 open advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   fast-uri: ^3.1.2
   ip-address: ^10.1.1
+  undici: ^7.29.0
 
 importers:
 
@@ -890,8 +891,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
@@ -1205,7 +1206,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.25.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   cliui@6.0.0:
@@ -1703,7 +1704,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.25.0: {}
+  undici@7.29.0: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,9 @@ onlyBuiltDependencies:
 overrides:
   fast-uri: ^3.1.2
   ip-address: ^10.1.1
+  # cheerio pulls undici ^7.19.0 for its fromURL() helper. We only ever call
+  # cheerio.load() on strings we already fetched ourselves, so none of these
+  # advisories is reachable from this codebase — but 12 open alerts on the
+  # default branch is noise that hides the next real one. 7.29.0 is the first
+  # release clear of all of them and still satisfies cheerio's range.
+  undici: ^7.29.0


### PR DESCRIPTION
Dependabot is reporting **12 open advisories** on the default branch — 4 high, 6 moderate, 2 low — and every one of them is the same package: `undici`, pulled in transitively by `cheerio` (`^7.19.0`, for its `fromURL()` helper).

## Reachability: none of them

Worth being precise rather than alarming. `cheerio` is used in exactly two places, and only ever as `cheerio.load()` on HTML this project already fetched through `AulaHttpClient`:

- `packages/aula-auth/src/html.ts`
- `packages/aula-auth/src/aula-saml-flow.ts`

`fromURL()` — the entry point that actually exercises undici's HTTP client — is never called. So none of the advisories (WebSocket DoS, SOCKS5 proxy pooling, TLS validation bypass, response queue poisoning, the various cookie/header injections) is reachable from this codebase.

## Why pin it anyway

Twelve standing alerts on `main` is noise, and noise is where the next *real* advisory goes to hide. This is cheap to clear.

`7.29.0` is the first release clear of all twelve, and still satisfies cheerio's `^7.19.0`, so the pin moves nothing else. Added to the existing `overrides` block in `pnpm-workspace.yaml` alongside the `fast-uri` / `ip-address` pins, with a comment recording the reachability finding so a future reader doesn't have to redo the analysis.

Verified `undici@7.29.0` resolves, and `pnpm typecheck` clean, `pnpm lint` clean, `bun test` 339 pass / 1 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nJqc1ztzhKN8P1Cchcwfr
