### PR TITLE
fix(ci): release one version, and report it in the MCP handshake

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,3 @@
 {
-  ".": "1.5.0",
-  "apps/cli": "1.4.0",
-  "packages/aula-auth": "1.1.1",
-  "packages/aula-client": "1.4.0",
-  "packages/mcp-server": "1.4.0"
+  ".": "1.5.0"
 }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@aula-mcp/cli",
-  "version": "1.4.0",
   "private": true,
   "description": "Command-line entry point for aula-mcp: login, status, logout.",
   "license": "MIT",

--- a/packages/aula-auth/package.json
+++ b/packages/aula-auth/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@aula-mcp/aula-auth",
-  "version": "1.1.1",
   "private": true,
   "description": "MitID + SRP + OAuth/SAML auth flow for Aula. Pure HTTP, no headless browser.",
   "license": "MIT",

--- a/packages/aula-client/package.json
+++ b/packages/aula-client/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@aula-mcp/aula-client",
-  "version": "1.4.0",
   "private": true,
   "description": "Aula API client + integration plugins (EasyIQ, Meebook, Min Uddannelse, Systematic).",
   "license": "MIT",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@aula-mcp/mcp-server",
-  "version": "1.4.0",
   "private": true,
   "description": "Hono-based MCP server exposing Aula data to AI agents. Runs on Bun.",
   "license": "MIT",

--- a/packages/mcp-server/src/setup.ts
+++ b/packages/mcp-server/src/setup.ts
@@ -9,6 +9,7 @@ import type { Logger } from '@aula-mcp/aula-auth';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { AulaContext } from './aula-context.ts';
 import { registerTools } from './tools.ts';
+import { VERSION } from './version.ts';
 
 const INSTRUCTIONS = [
   'This server exposes the Danish school platform Aula to AI agents.',
@@ -51,7 +52,7 @@ export function createMcpApp({ logger }: McpAppOptions): McpApp {
   const mcp = new McpServer(
     {
       name: 'aula-mcp',
-      version: '0.0.0',
+      version: VERSION,
     },
     {
       capabilities: { tools: {} },

--- a/packages/mcp-server/src/version.test.ts
+++ b/packages/mcp-server/src/version.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { VERSION } from './version.ts';
+
+/**
+ * release-please rewrites the annotated line in version.ts alongside the
+ * root package.json on every release. If that ever stops working, the MCP
+ * handshake silently starts advertising a stale version to every client —
+ * which is exactly how it sat on "0.0.0" unnoticed. Pin the two together.
+ */
+describe('VERSION', () => {
+  test('matches the version release-please writes to package.json', async () => {
+    const root = join(import.meta.dir, '..', '..', '..', 'package.json');
+    const pkg = JSON.parse(await readFile(root, 'utf8')) as { version: string };
+    expect(VERSION).toBe(pkg.version);
+  });
+
+  test('is a real version, not a placeholder', () => {
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+    expect(VERSION).not.toBe('0.0.0');
+  });
+});

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -1,0 +1,9 @@
+/**
+ * The version this server reports in the MCP `initialize` handshake.
+ *
+ * Kept as a literal rather than read from package.json: the CLI ships as a
+ * `bun build --compile` binary, where package.json is not on disk next to
+ * the code. release-please rewrites the annotated line on every release —
+ * do not edit it by hand.
+ */
+export const VERSION = '1.5.0'; // x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,24 +5,10 @@
   "separate-pull-requests": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "aula-mcp",
-      "components": [
-        "aula-mcp",
-        "@aula-mcp/cli",
-        "@aula-mcp/aula-auth",
-        "@aula-mcp/aula-client",
-        "@aula-mcp/mcp-server"
-      ]
-    }
-  ],
   "packages": {
-    ".": { "package-name": "aula-mcp" },
-    "apps/cli": { "package-name": "@aula-mcp/cli" },
-    "packages/aula-auth": { "package-name": "@aula-mcp/aula-auth" },
-    "packages/aula-client": { "package-name": "@aula-mcp/aula-client" },
-    "packages/mcp-server": { "package-name": "@aula-mcp/mcp-server" }
+    ".": {
+      "package-name": "aula-mcp",
+      "extra-files": ["packages/mcp-server/src/version.ts"]
+    }
   }
 }


### PR DESCRIPTION
## The symptom

After v1.5.0 the manifest was incoherent:

```json
{ ".": "1.5.0", "apps/cli": "1.4.0", "packages/aula-auth": "1.1.1",
  "packages/aula-client": "1.4.0", "packages/mcp-server": "1.4.0" }
```

`mcp-server` sat at 1.4.0 having just taken the posts feed, session eviction and the transport tests. `aula-auth` got a patch bump for work that included the token-redaction fix.

## The cause

The config declared five independently released packages, with a `linked-versions` plugin whose entire job was to keep them equal — but `include-component-in-tag: false` means every component wants the *same* tag, `v<version>`. Only one release can own that tag, so four of the five never got one and their manifest entries never advanced. The plugin was papering over a config that couldn't work.

The run log shows it complaining about this the whole time, once per component:

```
⚠ pullRequestTitlePattern miss the part of '${component}'
⚠ pullRequestTitlePattern miss the part of '${version}'
```

## The fix

Nothing here is published. All five packages are `"private": true`, they reference each other via `workspace:*` (never by version), and exactly one artifact ships — the tag that triggers `release.yml` to compile and attach the binaries. This is one product with one version, and the config now says so: a single root package, no `linked-versions` plugin to keep in step.

The `version` field is **removed** from the four private packages rather than frozen at a number. Frozen values would just rot further each release; absent ones can't lie. pnpm doesn't require a version for private packages, and `pnpm install` resolves unchanged.

## The bug found while fixing it

Checking what actually *reads* a version turned up `setup.ts`:

```ts
const mcp = new McpServer({ name: 'aula-mcp', version: '0.0.0' }, …)
```

The server has been advertising **`0.0.0`** to every MCP client in the `initialize` handshake — Claude Desktop, Claude Code, HA, all of them. It now reports the real version, from a constant `release-please` rewrites via `extra-files`.

A literal rather than a `package.json` read, deliberately: the CLI ships as a `bun build --compile` binary with no package.json beside it on disk.

A test pins that constant to the root `package.json` version, so it can't silently drift the way `0.0.0` did — that's the failure mode worth guarding, since a stale handshake version is invisible until someone asks a user what they're running.

## Note

The per-package `CHANGELOG.md` files under `apps/` and `packages/` will stop receiving entries. They're kept for history; the root `CHANGELOG.md` already carried every entry, so nothing is lost going forward.

`pnpm install` clean, `pnpm typecheck` clean, `pnpm lint` clean, `bun test` 343 pass / 1 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nJqc1ztzhKN8P1Cchcwfr
